### PR TITLE
[AESH-29] append a whitespace for "in-line" completion

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -1093,7 +1093,7 @@ public class Console {
             buffer.write(completion);
             terminal.writeToStdOut(completion);
         }
-        if(appendSpace && fullCompletion.startsWith(buffer.getLine())) {
+        if(appendSpace) {
             buffer.write(' ');
             terminal.writeToStdOut(' ');
         }


### PR DESCRIPTION
- Always append a space (if appendSpace is true) whether the line starts
  with the full completion or not.

This makes completion consistent:
- completion starts the line:
  deployment-over[TAB]
  => deployment-overlay[WHITESPACE][CURSOR]
- completion is inside the line:
  deployment-overlay a[TAB]
  => deployment-overlay add[WHITESPACE][CURSOR]
