### PR TITLE
PosixFileNameComparator ignored files named with 1 character

### DIFF
--- a/src/main/java/org/jboss/aesh/util/FileLister.java
+++ b/src/main/java/org/jboss/aesh/util/FileLister.java
@@ -440,7 +440,7 @@ public class FileLister {
     public static class PosixFileNameComparator implements Comparator<String> {
         @Override
         public int compare(String o1, String o2) {
-            if(o1.length() > 1 && o2.length() > 1) {
+            if(o1.length() > 0 && o2.length() > 0) {
                 if(o1.indexOf(DOT) == 0) {
                     if(o2.indexOf(DOT) == 0)
                         return o1.substring(1).compareToIgnoreCase(o2.substring(1));

--- a/src/test/java/org/jboss/aesh/util/FileListerTest.java
+++ b/src/test/java/org/jboss/aesh/util/FileListerTest.java
@@ -184,4 +184,25 @@ public class FileListerTest {
 
         return file.delete() && result;
     }
+
+    @Test
+    public void posixFileNameComparatorTest() {
+       FileLister.PosixFileNameComparator comparator = new FileLister.PosixFileNameComparator();
+
+       assertEquals("a".compareToIgnoreCase("b"), comparator.compare("a", "b"));
+       assertEquals("a".compareToIgnoreCase("b"), comparator.compare(".a", "b"));
+       assertEquals("a".compareToIgnoreCase("b"), comparator.compare("a", ".b"));
+
+       assertEquals("a".compareToIgnoreCase("b"), comparator.compare("A", "B"));
+
+       assertEquals("A".compareToIgnoreCase("b"), comparator.compare("A", "b"));
+       assertEquals("a".compareToIgnoreCase("B"), comparator.compare("a", "B"));
+       assertEquals("a".compareToIgnoreCase("B"), comparator.compare(".a", ".B"));
+       assertEquals("a".compareToIgnoreCase("B"), comparator.compare(".A", ".b"));
+
+       assertEquals("A".compareToIgnoreCase("b"), comparator.compare(".A", "b"));
+       assertEquals("A".compareToIgnoreCase("b"), comparator.compare("A", ".b"));
+       assertEquals("a".compareToIgnoreCase("B"), comparator.compare("a", ".B"));
+       assertEquals("a".compareToIgnoreCase("B"), comparator.compare(".a", "B"));
+    }
 }


### PR DESCRIPTION
When pressed <TAB> and files and directories were auto-completed. The files with one-character name were ignored and placed on random place.
