### PR TITLE
Completer do not show all possible directories when token length is 1

### DIFF
--- a/src/main/java/org/jboss/aesh/util/FileLister.java
+++ b/src/main/java/org/jboss/aesh/util/FileLister.java
@@ -326,7 +326,7 @@ public class FileLister {
     }
 
     private boolean endsWithParent() {
-        return token.lastIndexOf(parent) == token.length()-2;
+        return token.length() > 1 && token.lastIndexOf(parent) == token.length()-2;
     }
 
     private boolean startWithHome() {

--- a/src/test/java/org/jboss/aesh/util/FileListerTest.java
+++ b/src/test/java/org/jboss/aesh/util/FileListerTest.java
@@ -152,6 +152,21 @@ public class FileListerTest {
         delete(test, true);
     }
 
+    @Test
+    public void testDifferentLengthsOneCompletion() {
+        new File(workingDir, "b").mkdir();
+        new File(workingDir, "bb").mkdir();
+        new File(workingDir, "bbb").mkdir();
+
+        CompleteOperation completion = new CompleteOperation(aeshContext, "cd b", 4);
+        new FileLister("b", workingDir).findMatchingDirectories(completion);
+        List<TerminalString> candidates = completion.getCompletionCandidates();
+        assertEquals(3, candidates.size());
+        assertEquals("b" + Config.getPathSeparator(), candidates.get(0).getCharacters());
+        assertEquals("bb" + Config.getPathSeparator(), candidates.get(1).getCharacters());
+        assertEquals("bbb" + Config.getPathSeparator(), candidates.get(2).getCharacters());
+    }
+
     public static boolean delete(File file, final boolean recursive) {
         boolean result = false;
         if (recursive) {


### PR DESCRIPTION
Problem is in boolean endsWithParent() method which returns
incorrect value for token of lenght 1.
