### PR TITLE
PathResolver was not resolving "~" as home directory

### DIFF
--- a/src/main/java/org/jboss/aesh/util/PathResolver.java
+++ b/src/main/java/org/jboss/aesh/util/PathResolver.java
@@ -70,10 +70,12 @@ public class PathResolver {
         }
 
         if(incPath.toString().indexOf(TILDE) == 0) {
-            if(incPath.toString().length() > 1)
-                incPath = new File(Config.getPathSeparator() + incPath.toString().substring(1));
-            else
-                incPath = new File(Config.getPathSeparator());
+            if(incPath.toString().length() > 1) {
+                // directories which name starts with tilde
+                incPath = new File(cwd.toString() + Config.getPathSeparator() + incPath.toString());
+            } else {
+                incPath = new File(Config.getHomeDir());
+            }
         }
 
         //  foo1/./foo2 is changed to foo1/foo2

--- a/src/test/java/org/jboss/aesh/util/PathResolverTest.java
+++ b/src/test/java/org/jboss/aesh/util/PathResolverTest.java
@@ -99,8 +99,11 @@ public class PathResolverTest {
                 Config.getPathSeparator()+"child1"+Config.getPathSeparator()+"."+
                 Config.getPathSeparator()+"child11"+Config.getPathSeparator()+"."), child1).get(0));
 
-        //System.setProperty("user.home", tempDir.toString()+Config.getPathSeparator()+"home");
-        //assertEquals(new File(Config.getHomeDir()), PathResolver.resolvePath(new File("~/../home"), child1).get(0));
+        System.setProperty("user.home", tempDir.toString()+Config.getPathSeparator()+"home");
+        assertEquals(new File(Config.getHomeDir()), PathResolver.resolvePath(new File("~/../home"), child1).get(0));
+
+        assertEquals(new File(Config.getHomeDir()), PathResolver.resolvePath(new File("~"), child1).get(0));
+        assertEquals(new File(child1, "~a"), PathResolver.resolvePath(new File("~a"), child1).get(0));
     }
 
     @Test


### PR DESCRIPTION
PathResolver was not resolving "~" as home directory and returned "/"

Also "~xy" is now resolved as regular directory which name starts with tilde
