### PR TITLE
Completion fix when file in Java working directory has same name as token

### DIFF
--- a/src/main/java/org/jboss/aesh/util/FileLister.java
+++ b/src/main/java/org/jboss/aesh/util/FileLister.java
@@ -208,13 +208,6 @@ public class FileLister {
 
                 completion.setOffset(completion.getCursor() - token.length());
             }
-            else if (isTokenAFile()) {
-                completion.getCompletionCandidates().get(0).setCharacters(token +
-                    completion.getCompletionCandidates().get(0).getCharacters());
-
-                completion.setOffset(completion.getCursor() - token.length());
-                completion.doAppendSeparator(true);
-            }
             else if (token != null) {
                 if (rest != null && token.length() > rest.length()) {
                     completion.getCompletionCandidates().get(0).setCharacters(

--- a/src/test/java/org/jboss/aesh/util/FileListerTest.java
+++ b/src/test/java/org/jboss/aesh/util/FileListerTest.java
@@ -168,6 +168,23 @@ public class FileListerTest {
         assertEquals("bbb" + Config.getPathSeparator(), candidates.get(2).getCharacters());
     }
 
+    @Test
+    public void testWorkingDirFilePrefixCompletion() throws IOException {
+        File workingDirFile = new File("prefix");
+        workingDirFile.createNewFile();
+
+        new File(workingDir, "prefixdir").mkdir();
+
+        CompleteOperation completion = new CompleteOperation(aeshContext, "cd prefix", 9);
+        new FileLister("prefix", workingDir).findMatchingDirectories(completion);
+        List<TerminalString> candidates = completion.getCompletionCandidates();
+
+        assertEquals(1, candidates.size());
+        assertEquals("prefixdir" + Config.getPathSeparator(), candidates.get(0).getCharacters());
+
+        delete(workingDirFile, false);
+    }
+
     public static boolean delete(File file, final boolean recursive) {
         boolean result = false;
         if (recursive) {


### PR DESCRIPTION
Steps to reproduce:

Example of directory structure:

homedir/file
homedir/dir1/file2
1. Run application from "homedir" directory
2. Change directory to "drectory1"
3. Input "file<TAB>" and "filefile2" is completed

Test case included.
