### PR TITLE
[AESH-260] Not load System.getenv() on forge.

### DIFF
--- a/src/main/java/org/jboss/aesh/console/settings/SettingsImpl.java
+++ b/src/main/java/org/jboss/aesh/console/settings/SettingsImpl.java
@@ -99,6 +99,7 @@ public class SettingsImpl implements Settings {
         setExportFile(baseSettings.getExportFile());
         setPersistExport(baseSettings.doPersistExport());
         setResource(baseSettings.getResource());
+        setExportUsesSystemEnvironment(baseSettings.doExportUsesSystemEnvironment());
     }
 
     public void resetToDefaults() {


### PR DESCRIPTION
That's necessary when I "copy" settings.
Altered SettingsImpl
