### PR TITLE
Updating pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
             <configuration>
                <redirectTestOutputToFile>true</redirectTestOutputToFile>
                <trimStackTrace>false</trimStackTrace>
-               <printSummary>true</printSummary>
                <includes>
                   <include>**/*TestCase.java</include>
                   <include>**/*Test.java</include>
@@ -63,7 +62,6 @@
                <excludes>
                   <exclude>**/ConsoleRedirectionTest.java</exclude>
                </excludes>
-               <useFile>true</useFile>
             </configuration>
          </plugin>
          <plugin>
@@ -86,15 +84,5 @@
          </plugin>
       </plugins>
    </build>
-
-   <reporting>
-      <plugins>
-         <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
-            <version>2.5.4-SNAPSHOT</version>
-         </plugin>
-      </plugins>
-   </reporting>
 
 </project>


### PR DESCRIPTION
- Removing default true values from surefire-plugin
- Removing findbugs-maven-plugin because we can use:

``` shell
$ mvn clean findbugs:findbugs
```

``` shell
$ mvn findbugs:gui
```

To check the results if needed.
