### PR TITLE
[WFLY-1628] alias --help print nothing on jboss-cli

### DIFF
--- a/src/main/java/org/jboss/aesh/console/alias/AliasCompletion.java
+++ b/src/main/java/org/jboss/aesh/console/alias/AliasCompletion.java
@@ -30,6 +30,7 @@ public class AliasCompletion implements Completion {
     private static final String ALIAS_SPACE = "alias ";
     private static final String UNALIAS = "unalias";
     private static final String UNALIAS_SPACE = "unalias ";
+    private static final String HELP = "--help";
     private final AliasManager manager;
 
     public AliasCompletion(AliasManager manager) {
@@ -51,12 +52,16 @@ public class AliasCompletion implements Completion {
         else if(completeOperation.getBuffer().equals(ALIAS_SPACE) ||
                 completeOperation.getBuffer().equals(UNALIAS_SPACE)) {
             completeOperation.addCompletionCandidates(manager.getAllNames());
+            completeOperation.addCompletionCandidate(HELP);
             completeOperation.setOffset(completeOperation.getCursor());
         }
         else if(completeOperation.getBuffer().startsWith(ALIAS_SPACE) ||
                 completeOperation.getBuffer().startsWith(UNALIAS_SPACE)) {
             String word = Parser.findCurrentWordFromCursor(completeOperation.getBuffer(), completeOperation.getCursor());
             completeOperation.addCompletionCandidates(manager.findAllMatchingNames(word));
+            if (HELP.startsWith(word)) {
+                completeOperation.addCompletionCandidate(HELP);
+            }
             completeOperation.setOffset(completeOperation.getCursor()-word.length());
         }
     }

--- a/src/main/java/org/jboss/aesh/console/alias/AliasManager.java
+++ b/src/main/java/org/jboss/aesh/console/alias/AliasManager.java
@@ -42,6 +42,8 @@ public class AliasManager {
     private final List<Alias> aliases;
     private final Pattern aliasPattern = Pattern.compile("^(alias)\\s+(\\w+)\\s*=\\s*(.*)$");
     private final Pattern listAliasPattern = Pattern.compile("^(alias)((\\s+\\w+)+)$");
+    private final Pattern aliasHelpPattern = Pattern.compile("^(" + ALIAS + ")\\s+\\-\\-help$");
+    private final Pattern unaliasHelpPattern = Pattern.compile("^(" + UNALIAS + ")\\s+\\-\\-help$");
     private static final String ALIAS = "alias";
     private static final String ALIAS_SPACE = "alias ";
     private static final String UNALIAS = "unalias";
@@ -139,7 +141,9 @@ public class AliasManager {
 
     public String removeAlias(String buffer) {
         if(buffer.trim().equals(UNALIAS))
-            return "unalias: usage: unalias name [name ...]"+Config.getLineSeparator();
+            return unaliasUsage();
+        if (unaliasHelpPattern.matcher(buffer).matches())
+            return unaliasUsage();
 
         buffer = buffer.substring(UNALIAS.length()).trim();
         for(String s : buffer.split(" ")) {
@@ -157,6 +161,8 @@ public class AliasManager {
     public String parseAlias(String buffer) {
         if(buffer.trim().equals(ALIAS))
             return printAllAliases();
+        if (aliasHelpPattern.matcher(buffer).matches())
+            return aliasUsage();
         Matcher aliasMatcher = aliasPattern.matcher(buffer);
         if(aliasMatcher.matches()) {
             String name = aliasMatcher.group(2);
@@ -165,16 +171,16 @@ public class AliasManager {
                 if(value.endsWith("'"))
                     value = value.substring(1,value.length()-1);
                 else
-                    return "alias: usage: alias [name[=value] ... ]"+Config.getLineSeparator();
+                    return aliasUsage();
             }
             else if(value.startsWith("\"")) {
                 if(value.endsWith("\""))
                     value = value.substring(1,value.length()-1);
                 else
-                    return "alias: usage: alias [name[=value] ... ]"+Config.getLineSeparator();
+                    return aliasUsage();
             }
             if(name.contains(" "))
-                return "alias: usage: alias [name[=value] ... ]"+Config.getLineSeparator();
+                return aliasUsage();
 
             addAlias(name, value);
             return null;
@@ -197,6 +203,14 @@ public class AliasManager {
             return sb.toString();
         }
         return null;
+    }
+
+    private String aliasUsage() {
+        return "alias: usage: alias [name[=value] ... ]"+Config.getLineSeparator();
+    }
+
+    private String unaliasUsage() {
+        return "unalias: usage: unalias name [name ...]"+Config.getLineSeparator();
     }
 
 }

--- a/src/test/java/org/jboss/aesh/console/alias/AliasManagerTest.java
+++ b/src/test/java/org/jboss/aesh/console/alias/AliasManagerTest.java
@@ -63,6 +63,13 @@ public class AliasManagerTest {
                 .append("alias foo2='bar -s -h'").append(Config.getLineSeparator())
                 .append("alias foo3='bar --help'").append(Config.getLineSeparator());
         assertEquals(sb.toString(), out);
+
+        // the help information for the (un)alias itself
+        out = manager.parseAlias("alias --help");
+        assertEquals("alias: usage: alias [name[=value] ... ]" + Config.getLineSeparator(), out);
+
+        out = manager.parseAlias("alias        --help");
+        assertEquals("alias: usage: alias [name[=value] ... ]" + Config.getLineSeparator(), out);
     }
 
     @Test
@@ -74,6 +81,12 @@ public class AliasManagerTest {
 
         manager.removeAlias("unalias foo3");
         assertEquals("aesh: unalias: foo3: not found"+Config.getLineSeparator(), manager.removeAlias("unalias foo3"));
+
+        String out = manager.removeAlias("unalias --help");
+        assertEquals("unalias: usage: unalias name [name ...]" + Config.getLineSeparator(), out);
+
+        out = manager.removeAlias("unalias        --help");
+        assertEquals("unalias: usage: unalias name [name ...]" + Config.getLineSeparator(), out);
     }
 
     @Test


### PR DESCRIPTION
Command: 'alias' needs to provide some help information to the console if it is enabled, and it is enabled in wildfly console. :smile: 

Would you please review if the fix is OK?

And, since wildfly uses aesh:0.33.12, I also made another branch: https://github.com/gaol/aesh/tree/WFLY-1628-033 which contains this fix, should we make a new tag and upgrade the reference in wildfly to the new tag?
