### PR TITLE
AESH-282 Interpret arrow key sequences correctly in Win.

### DIFF
--- a/src/main/java/org/jboss/aesh/console/reader/AeshInputStream.java
+++ b/src/main/java/org/jboss/aesh/console/reader/AeshInputStream.java
@@ -75,10 +75,17 @@ public class AeshInputStream extends InputStream {
                         (out.charAt(0) == Key.WINDOWS_ESC.getAsChar() ||
                                 out.charAt(0) == Key.WINDOWS_ESC_2.getAsChar())) {
                     int[] input = new int[2];
-                    //set the first char to WINDOWS_ESC, then we can reduce the number of different key's in the future
-                    input[0] = Key.WINDOWS_ESC.getAsChar();
-                    String out2 = blockingQueue.take();
-                    input[1] = out2.charAt(0);
+                    if (out.length() == 2) {
+                        // If there are two characters, then the first is WINDOWS_ESC, and the second is what follows it. 
+                        input[0] = Key.WINDOWS_ESC.getAsChar();
+                        input[1] = out.charAt(1);
+                    }
+                    else {
+                        // Otherwise, set the first char to WINDOWS_ESC, then we can reduce the number of different key's in the future
+                        input[0] = Key.WINDOWS_ESC.getAsChar();
+                        String out2 = blockingQueue.take();
+                        input[1] = out2.charAt(0);
+                    }
 
                     return input;
                 }


### PR DESCRIPTION
This ensures that arrows keys consisting of control characters, like 224;72 for up arrow are interpreted correctly on Windows.
