### PR TITLE
[BZ-1169300] The CLI freezes in phase of requesting username/password

### DIFF
--- a/src/main/java/org/jboss/aesh/console/reader/ConsoleInputSession.java
+++ b/src/main/java/org/jboss/aesh/console/reader/ConsoleInputSession.java
@@ -36,7 +36,11 @@ public class ConsoleInputSession {
             public int read() throws IOException {
                 try {
                     if (b == null || c == b.length()) {
-                        b = blockingQueue.poll(365, TimeUnit.DAYS);
+                        if (connected) {
+                            b = blockingQueue.poll(365, TimeUnit.DAYS);
+                        } else {
+                            b = blockingQueue.poll(); // if reader is closed, there's no point in waiting
+                        }
                         c = 0;
                     }
 


### PR DESCRIPTION
- reading freezes when using unix redirection
