### PR TITLE
Throwing null-pointer

### DIFF
--- a/src/main/java/org/jboss/aesh/console/AeshConsoleCallback.java
+++ b/src/main/java/org/jboss/aesh/console/AeshConsoleCallback.java
@@ -33,7 +33,11 @@ public abstract class AeshConsoleCallback implements ConsoleCallback {
 
     @Override
     public CommandOperation getInput() throws InterruptedException {
-        return process.getInput();
+        if( process != null ) {
+            return process.getInput();
+        }else{
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Line 184 in commit https://github.com/stalep/wildfly-core/commit/df5dcfe368aab287481c206f6573dbcbc244fad2 is throwing null-pointer errors when the CLI starts up. Clean build, but the CLI startup fails. Traced it back to the process not existing when the first read gets called. Not sure if you want it handled here or elsewhere.