### PR TITLE
[AESH-298] manage root path with driver name in PathResolver (cloverxell issue #87)

### DIFF
--- a/src/main/java/org/jboss/aesh/io/PathResolver.java
+++ b/src/main/java/org/jboss/aesh/io/PathResolver.java
@@ -47,6 +47,7 @@ public class PathResolver {
     private static final String PARENT = "..";
     private static final String PARENT_WITH_SEPARATOR = ".."+ Config.getPathSeparator();
     private static final String ROOT = Config.getPathSeparator();
+    private static final String DRIVER_SEPARATOR = ":";
     private static final String CURRENT_WITH_SEPARATOR = "."+Config.getPathSeparator();
     private static final String SEPARATOR_WITH_CURRENT = Config.getPathSeparator()+".";
     private static final String SEPARATOR_CURRENT_SEPARATOR = Config.getPathSeparator()+"."+Config.getPathSeparator();
@@ -108,8 +109,8 @@ public class PathResolver {
             incPath = new File(incPath.toString().substring(0, incPath.toString().length()-SEPARATOR_WITH_CURRENT.length()));
         }
 
-        //parentPath do not start with / and cwd is not / either
-        if(incPath.toString().indexOf(ROOT) != 0 && !cwd.toString().equals(ROOT)) {
+        //parentPath do not start with / or by a windows driver letter and cwd is not / either
+        if( incPath.toString().indexOf(ROOT) != 0 && incPath.toString().indexOf(DRIVER_SEPARATOR) == -1 && !cwd.toString().equals(ROOT)) {
             if(cwd.toString().endsWith(Config.getPathSeparator()))
                 incPath = new File(cwd.toString() + incPath.toString());
             else

--- a/src/test/java/org/jboss/aesh/io/PathResolverTest.java
+++ b/src/test/java/org/jboss/aesh/io/PathResolverTest.java
@@ -211,6 +211,15 @@ public class PathResolverTest {
         assertTrue(actual.contains(child111));
     }
 
+
+    @Test
+    public void testResolveWithWindowsRootPath() throws IOException {
+        Resource root = new FileResource("C:\\users\\me");
+        List<Resource> restult = root.resolve(root);
+        assertEquals(1, restult.size());
+        assertEquals(root.getAbsolutePath(), restult.get(0).getAbsolutePath());
+    }
+
     /* private testing...
     @Test
     public void testNIO() {


### PR DESCRIPTION
For Windows platform the root path do not start with "/" bur more like C: 
Hope that help.

Regards,
Jérémie. 