### PR TITLE
create DefaultAeshContext and make it easy to extend

### DIFF
--- a/src/main/java/org/jboss/aesh/console/settings/DefaultAeshContext.java
+++ b/src/main/java/org/jboss/aesh/console/settings/DefaultAeshContext.java
@@ -20,16 +20,22 @@
 package org.jboss.aesh.console.settings;
 
 import org.jboss.aesh.console.AeshContext;
+import org.jboss.aesh.console.Config;
+import org.jboss.aesh.io.FileResource;
 import org.jboss.aesh.io.Resource;
 
 /**
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
  */
-public class AeshContextImpl implements AeshContext {
+public class DefaultAeshContext implements AeshContext {
 
     private Resource cwd;
 
-    AeshContextImpl(Resource cwd) {
+    public DefaultAeshContext() {
+        this(new FileResource("").newInstance(Config.getUserDir()));
+    }
+
+    public DefaultAeshContext(Resource cwd) {
         if(cwd != null && (!cwd.isLeaf() && cwd.exists()))
             this.cwd = cwd;
         else

--- a/src/main/java/org/jboss/aesh/console/settings/SettingsImpl.java
+++ b/src/main/java/org/jboss/aesh/console/settings/SettingsImpl.java
@@ -611,7 +611,7 @@ public class SettingsImpl implements Settings {
     @Override
     public AeshContext getAeshContext() {
         if(aeshContext == null)
-            aeshContext = new AeshContextImpl(getResource().newInstance(Config.getUserDir()));
+            aeshContext = new DefaultAeshContext(getResource().newInstance(Config.getUserDir()));
         return aeshContext;
     }
 


### PR DESCRIPTION
I needed my own AeshContext for Artificer and used AeshContextImpl to provide the base methods.  But, it's easier to extend with this PR.  Also re-named it DefaultAeshContext.  Feel free to take it or leave it -- not sure if others are extending it as-is and whether or not this would be breaking.