### PR TITLE
Adding newline before interrupt

### DIFF
--- a/src/main/java/org/jboss/aesh/console/AeshInputProcessor.java
+++ b/src/main/java/org/jboss/aesh/console/AeshInputProcessor.java
@@ -167,6 +167,7 @@ public class AeshInputProcessor implements InputProcessor {
         else if(action == Action.EXIT || action == Action.EOF ||
                 action == Action.INTERRUPT || action == Action.IGNOREEOF) {
             if(interruptHook != null) {
+                consoleBuffer.out().print(Config.getLineSeparator());
                 interruptHook.handleInterrupt(action);
             }
         }


### PR DESCRIPTION
Necessary to put the next prompt after a ctrl-c exit on a clean line.