### PR TITLE
Allow for nested processes via low-level API

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -439,12 +439,18 @@ public class Console {
         return inputProcessor;
     }
 
-    protected void putProcessInBackground(int pid) {
+    /**
+     * Put the current process in the background
+     */
+    public void putProcessInBackground(int pid) {
         processManager.putProcessInBackground(pid);
     }
 
-    protected void putProcessInForeground(int pid) {
-        processManager.putProcessInBackground(pid);
+    /**
+     * Put the current process in the foreground
+     */
+    public void putProcessInForeground(int pid) {
+        processManager.putProcessInForeground(pid);
     }
 
     public void pushToInputStream(String input) {


### PR DESCRIPTION
Simplest solution for nesting commands on the low-level API.

It leaves it up to whoever is using AESH to create their own callbackhandler that keeps track of the active process PID, if there is an active process, to pass into the methods.

I figure if they want AESH to take care of the PID handling they should be using the high-level API.