### PR TITLE
Runtime enable/disable of completion capabilities

### DIFF
--- a/src/main/java/org/jboss/aesh/console/AeshCompletionHandler.java
+++ b/src/main/java/org/jboss/aesh/console/AeshCompletionHandler.java
@@ -45,6 +45,8 @@ import java.util.logging.Logger;
  */
 public class AeshCompletionHandler implements CompletionHandler {
 
+    private volatile boolean enabled = true;
+
     private final AeshContext aeshContext;
     private boolean askDisplayCompletion = false;
     private int displayCompletionSize = 100;
@@ -63,6 +65,11 @@ public class AeshCompletionHandler implements CompletionHandler {
         this.consoleBuffer = consoleBuffer;
         this.shell = shell;
         this.doLogging = doLogging;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled){
+        this.enabled = enabled;
     }
 
     @Override
@@ -111,6 +118,9 @@ public class AeshCompletionHandler implements CompletionHandler {
      */
     @Override
     public void complete(PrintStream out, Buffer buffer) throws IOException {
+        if(!enabled)
+            return;
+
         if(completionList.size() < 1)
             return;
 

--- a/src/main/java/org/jboss/aesh/console/AeshInputProcessor.java
+++ b/src/main/java/org/jboss/aesh/console/AeshInputProcessor.java
@@ -270,6 +270,11 @@ public class AeshInputProcessor implements InputProcessor {
     }
 
     @Override
+    public CompletionHandler getCompleter(){
+        return completionHandler;
+    }
+
+    @Override
     public void clearBufferAndDisplayPrompt() {
         consoleBuffer.getBuffer().reset();
         consoleBuffer.getUndoManager().clear();

--- a/src/main/java/org/jboss/aesh/console/CompletionHandler.java
+++ b/src/main/java/org/jboss/aesh/console/CompletionHandler.java
@@ -30,6 +30,8 @@ import java.io.PrintStream;
  */
 public interface CompletionHandler {
 
+    void setEnabled(boolean enabled);
+
     void addCompletion(Completion completion);
 
     void removeCompletion(Completion completion);

--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -372,6 +372,15 @@ public class Console {
         };
     }
 
+    /**
+     * Runtime enable/disable of completion capabilities
+     *
+     * @param completionEnabled
+     */
+    public void setCompletionEnabled(boolean completionEnabled){
+        completionHandler.setEnabled(completionEnabled);
+    }
+
     public void stop() {
        initiateStop = true;
        try {

--- a/src/main/java/org/jboss/aesh/console/InputProcessor.java
+++ b/src/main/java/org/jboss/aesh/console/InputProcessor.java
@@ -33,6 +33,8 @@ public interface InputProcessor {
 
     History getHistory();
 
+    CompletionHandler getCompleter();
+
     void clearBufferAndDisplayPrompt();
 
     void resetBuffer();

--- a/src/main/java/org/jboss/aesh/console/settings/Settings.java
+++ b/src/main/java/org/jboss/aesh/console/settings/Settings.java
@@ -126,7 +126,7 @@ public interface Settings extends Cloneable {
     /**
      * Is completion disabled
      */
-    boolean isDisableCompletion();
+    boolean isCompletionDisabled();
 
     /**
      * Get location of log file

--- a/src/main/java/org/jboss/aesh/console/settings/SettingsImpl.java
+++ b/src/main/java/org/jboss/aesh/console/settings/SettingsImpl.java
@@ -97,7 +97,7 @@ public class SettingsImpl implements Settings {
         setTerminal(baseSettings.getTerminal());
         setInputrc(baseSettings.getInputrc());
         setLogging(baseSettings.isLogging());
-        setDisableCompletion(baseSettings.isDisableCompletion());
+        setDisableCompletion(baseSettings.isCompletionDisabled());
         setLogFile(baseSettings.getLogFile());
         setReadInputrc(baseSettings.doReadInputrc());
         setHistoryDisabled(baseSettings.isHistoryDisabled());
@@ -433,7 +433,7 @@ public class SettingsImpl implements Settings {
      * @return dis completion
      */
     @Override
-    public boolean isDisableCompletion() {
+    public boolean isCompletionDisabled() {
         return disableCompletion;
     }
 

--- a/src/test/java/org/jboss/aesh/console/ConfigTest.java
+++ b/src/test/java/org/jboss/aesh/console/ConfigTest.java
@@ -51,7 +51,7 @@ public class ConfigTest {
 
         assertEquals(settings.getHistorySize(), 300);
 
-        assertEquals(settings.isDisableCompletion(), true);
+        assertEquals(settings.isCompletionDisabled(), true);
 
     }
 
@@ -100,7 +100,7 @@ public class ConfigTest {
         assertEquals(settings.isHistoryDisabled(), true);
         assertEquals(settings.getHistorySize(), 42);
         assertEquals(settings.isLogging(), false);
-        assertEquals(settings.isDisableCompletion(), true);
+        assertEquals(settings.isCompletionDisabled(), true);
 
         assertEquals(settings.getExecuteAtStart(), "foo -f --bar"+Config.getLineSeparator());
 


### PR DESCRIPTION
Necessary in order to disable completion on nested commands. If, for example, a nested command is requesting a username/password, completion needs to be off. Tried to design it like enabling/disabling history worked. Keeping the variable and functionality within the the CompletionHandler instead of the Console or InputProcessor. 

I think I need to give more thought to nested commands in general. Ideally they would be almost brand new consoles, with their own settings and handlers. I'm not sure how complicated that would be though. Could require a lot of work.

