### PR TITLE
Fixing cursor movement when using null character masking and hitting backspace

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Buffer.java
+++ b/src/main/java/org/jboss/aesh/console/Buffer.java
@@ -122,7 +122,7 @@ public class Buffer {
     }
 
     protected int getCursor() {
-        return (prompt.isMasking() && prompt.getMask() == 0) ? 0 : cursor;
+        return (prompt.isMasking() && prompt.getMask() == 0) ? 1 : cursor;
     }
 
     protected int getCursorWithPrompt() {


### PR DESCRIPTION
If the length() method in line 109 is going to return 1 when null masking is enabled, then the cursor location has to be 1 when it's enabled. Otherwise the cursor will move forward 1 column when backspace is used.