### PR TITLE
Fixing Cursor movement while using Zero-Masking

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Buffer.java
+++ b/src/main/java/org/jboss/aesh/console/Buffer.java
@@ -122,7 +122,7 @@ public class Buffer {
     }
 
     protected int getCursor() {
-        return (prompt.isMasking() && prompt.getMask() == 0) ? 1 : cursor;
+        return (prompt.isMasking() && prompt.getMask() == 0) ? 0 : cursor;
     }
 
     protected int getCursorWithPrompt() {
@@ -212,6 +212,15 @@ public class Buffer {
         int row = newRow - currentRow;
 
         setCursor(getCursor() + move);
+
+        // 0 Masking separates the UI cursor position from the 'real' cursor position.
+        // Cursor movement still has to occur, via moveCursor and setCursor above,
+        // to put new characters in the correct location in the invisible line,
+        // but this method should always return an empty character so the UI cursor does not move.
+        if(prompt.isMasking() && prompt.getMask() == 0){
+            return new char[0];
+        }
+
         int cursor = getCursorWithPrompt() % termWidth;
         if(cursor == 0 && getCursorWithPrompt() > 0)
             cursor = termWidth;


### PR DESCRIPTION
Changing previous fix for cursor movement during 0 masking issue. Previous solution introduced ArrayIndexOutOfBounds exceptions in certain edge cases.

The existing tests in AeshInputProcessorTest don't cover zero-masking correctly, because they get the buffer 'line', which always returns nothing, but doesn't necessarily reflect the actual console output. However, I've been messing with input and output streams all day and can't get a test for it to work correctly.

