### PR TITLE
Terminal needs to reset on close even if the console has not been started and running=false

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -422,8 +422,6 @@ public class Console {
                 LOGGER.log(Level.WARNING, "InputQueue still contains items after stop: "+inputQueue.toString());
             }
 
-            getTerminal().close();
-            getTerminal().reset();
             inputProcessor.getHistory().stop();
             if(aliasManager != null)
                 aliasManager.persist();
@@ -441,6 +439,9 @@ public class Console {
             if(settings.isLogging())
                 LOGGER.info("Streams are closed");
         }
+
+        getTerminal().close();
+        getTerminal().reset();
     }
 
     /**


### PR DESCRIPTION
Odd edge-case. In some CLI scenarios the console can be created, but then closed without being started. The terminal still needs to reset.

I'm not sure if the other stream closing, lines 436-438, might need this change as well. I only encountered the terminal problem specifically.