### PR TITLE
Avoid closing stderr and stdout

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -452,11 +452,6 @@ public class Console {
             executorService.shutdown();
             if(settings.isLogging())
                 LOGGER.info("Done stopping services. Terminal is reset");
-
-            settings.getStdErr().close();
-            settings.getStdOut().close();
-            if(settings.isLogging())
-                LOGGER.info("Streams are closed");
         }
 
         getTerminal().close();


### PR DESCRIPTION
Aesh should never attempt to close streams that were not created by Aesh. 
Attempting to close it while reading the stream provokes a deadlock