### PR TITLE
Fix creation of .aesh_alias file

### DIFF
--- a/src/main/java/org/jboss/aesh/console/alias/AliasManager.java
+++ b/src/main/java/org/jboss/aesh/console/alias/AliasManager.java
@@ -92,7 +92,7 @@ public class AliasManager {
                     keepGoing = aliasFile.delete();
 
                 if(keepGoing) {
-                    aliasFile.mkdirs();
+                    aliasFile.getParentFile().mkdirs();
                     keepGoing = aliasFile.createNewFile();
                 }
 

--- a/src/main/java/org/jboss/aesh/console/alias/AliasManager.java
+++ b/src/main/java/org/jboss/aesh/console/alias/AliasManager.java
@@ -92,7 +92,10 @@ public class AliasManager {
                     keepGoing = aliasFile.delete();
 
                 if(keepGoing) {
-                    aliasFile.getParentFile().mkdirs();
+                    File parentFile = aliasFile.getParentFile();
+                    if (parentFile != null) {
+                        parentFile.mkdirs();
+                    }
                     keepGoing = aliasFile.createNewFile();
                 }
 

--- a/src/test/java/org/jboss/aesh/console/alias/AliasManagerTest.java
+++ b/src/test/java/org/jboss/aesh/console/alias/AliasManagerTest.java
@@ -20,6 +20,7 @@
 package org.jboss.aesh.console.alias;
 
 import org.jboss.aesh.console.Config;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
@@ -36,14 +38,21 @@ import static org.junit.Assert.assertNull;
 public class AliasManagerTest {
 
     private AliasManager manager;
+    private File fooFile;
 
     @Before
     public void setTup() {
         try {
-            manager = new AliasManager(new File("foo"), false, "aesh");
+            fooFile = new File("foo");
+            manager = new AliasManager(fooFile, true, "aesh");
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @After
+    public void cleanup() {
+        fooFile.delete();
     }
 
     @Test
@@ -98,4 +107,9 @@ public class AliasManagerTest {
         Assert.assertEquals(alias + Config.getLineSeparator(), manager.printAllAliases());
     }
 
+    @Test
+    public void testPersist() throws Exception {
+        manager.persist();
+        assertTrue("The persistent file should be a file", fooFile.isFile());
+    }
 }


### PR DESCRIPTION
When writing its persistent file, the AliasManager drop the existing one and replace it with an empty directory. The bug can be seen with the AeshExample or with WildFly 10.CR4.
With the fix, it creates the parent directory when needed and the only creates the file. 