### PR TITLE
follow up AESH-340, fix double prompt string problem reported in WFCORE-1277

### DIFF
--- a/src/main/java/org/jboss/aesh/console/AeshConsoleBuffer.java
+++ b/src/main/java/org/jboss/aesh/console/AeshConsoleBuffer.java
@@ -56,6 +56,7 @@ public class AeshConsoleBuffer implements ConsoleBuffer {
     private Action currentAction = Action.EDIT;
 
     private final boolean isLogging = false;
+    private boolean prompted = false;
 
     //used to optimize text deletion
     private static final char[] resetLineAndSetCursorToStart =
@@ -422,6 +423,7 @@ public class AeshConsoleBuffer implements ConsoleBuffer {
                     buffer.setCursor(buffer.getLine().length());
                     out().flush();
                 }
+                prompted = true;
             }
         }
     }
@@ -603,4 +605,13 @@ public class AeshConsoleBuffer implements ConsoleBuffer {
         }
     }
 
+    @Override
+    public boolean isPrompted() {
+        return prompted;
+    }
+
+    @Override
+    public void setPrompted(boolean prompted) {
+        this.prompted = prompted;
+    }
 }

--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -352,6 +352,7 @@ public class Console {
         running = true;
         startReader();
         startExecutor();
+        consoleBuffer.setPrompted(false);
         if(settings.getExecuteAtStart() != null)
             pushToInputStream(settings.getExecuteAtStart());
         if(settings.getExecuteFileAtStart() != null) {
@@ -573,9 +574,12 @@ public class Console {
         else {
             if(running || !inputQueue.isEmpty()) {
                 inputProcessor.resetBuffer();
-                displayPrompt();
+                if (!consoleBuffer.isPrompted()) {
+                    displayPrompt();
+                }
             }
         }
+        consoleBuffer.setPrompted(false);
     }
 
     private Terminal getTerminal() {
@@ -1180,4 +1184,5 @@ public class Console {
             shell.enableMainBuffer();
         }
     }
+
 }

--- a/src/main/java/org/jboss/aesh/console/ConsoleBuffer.java
+++ b/src/main/java/org/jboss/aesh/console/ConsoleBuffer.java
@@ -86,6 +86,10 @@ public interface ConsoleBuffer {
 
     void setPrompt(Prompt prompt);
 
+    boolean isPrompted();
+
+    void setPrompted(boolean prompted);
+
     void setBufferLine(String line);
 
     void insertBufferLine(String insert, int position);


### PR DESCRIPTION
an aesh 0.66.2 upgrade causes https://issues.jboss.org/browse/WFCORE-1277
which seems like an incomplete fix through https://github.com/aeshell/aesh/commit/103dbff7eaef1921275458181898a908737b3950

Could component leader review this? I have locally tested the two cases in WFCORE-1277. it fixed the double prompt string problem. 