### PR TITLE
Allow for Command with dynamic options and dynamic child commands

### DIFF
--- a/src/main/java/org/jboss/aesh/cl/internal/ProcessedCommand.java
+++ b/src/main/java/org/jboss/aesh/cl/internal/ProcessedCommand.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
  */
-public final class ProcessedCommand<C extends Command> {
+public class ProcessedCommand<C extends Command> {
 
     private String name;
     private String description;
@@ -162,7 +162,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public ProcessedOption findOption(String name) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             if(option.getShortName() != null &&
                     option.getShortName().equals(name) &&
                     option.getActivator().isActivated(this))
@@ -172,7 +172,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public ProcessedOption findOptionNoActivatorCheck(String name) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             if(option.getShortName() != null &&
                     option.getShortName().equals(name))
                 return option;
@@ -181,7 +181,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public ProcessedOption findLongOption(String name) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             if(option.getName() != null &&
                     option.getName().equals(name) &&
                     option.getActivator().isActivated(this))
@@ -191,7 +191,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public ProcessedOption findLongOptionNoActivatorCheck(String name) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             if(option.getName() != null && option.getName().equals(name))
                 return option;
 
@@ -199,7 +199,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public ProcessedOption startWithOption(String name) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             if(option.getShortName() != null && name.startsWith(option.getShortName()) &&
                     option.getActivator().isActivated(this))
                 return option;
@@ -208,7 +208,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public ProcessedOption startWithLongOption(String name) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             if(name.startsWith(option.getName()) &&
                     option.getActivator().isActivated(this))
                 return option;
@@ -217,7 +217,7 @@ public final class ProcessedCommand<C extends Command> {
     }
 
    public void clear() {
-       for(ProcessedOption processedOption : options)
+       for (ProcessedOption processedOption : getOptions())
            processedOption.clear();
        if(argument != null)
            argument.clear();
@@ -228,8 +228,9 @@ public final class ProcessedCommand<C extends Command> {
      * and is enabled
      */
     public List<TerminalString> getOptionLongNamesWithDash() {
-        List<TerminalString> names = new ArrayList<>(options.size());
-        for(ProcessedOption o : options) {
+        List<ProcessedOption> opts = getOptions();
+        List<TerminalString> names = new ArrayList<>(opts.size());
+        for (ProcessedOption o : opts) {
             if(o.getValues().size() == 0 &&
                     o.getActivator().isActivated(this))
                 names.add(o.getRenderedNameWithDashes());
@@ -239,8 +240,9 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public List<TerminalString> findPossibleLongNamesWitdDash(String name) {
-        List<TerminalString> names = new ArrayList<>(options.size());
-        for(ProcessedOption o : options) {
+        List<ProcessedOption> opts = getOptions();
+        List<TerminalString> names = new ArrayList<>(opts.size());
+        for (ProcessedOption o : opts) {
            if(((o.getShortName() != null && o.getShortName().equals(name) &&
                    !o.isLongNameUsed() && o.getValues().size() == 0) ||
                    (o.getName().startsWith(name) && o.getValues().size() == 0)) &&
@@ -258,14 +260,15 @@ public final class ProcessedCommand<C extends Command> {
     public String printHelp() {
         int maxLength = 0;
         int width = 80;
-        for(ProcessedOption o : getOptions())
+        List<ProcessedOption> opts = getOptions();
+        for (ProcessedOption o : opts)
             if(o.getFormattedLength() > maxLength)
                 maxLength = o.getFormattedLength();
 
         StringBuilder sb = new StringBuilder();
-        if(getOptions().size() > 0)
+        if (opts.size() > 0)
            sb.append(Config.getLineSeparator()).append("Options:").append(Config.getLineSeparator());
-        for(ProcessedOption o : getOptions())
+        for (ProcessedOption o : opts)
             sb.append(o.getFormattedOption(2, maxLength+4, width)).append(Config.getLineSeparator());
         if(argument != null) {
             sb.append(Config.getLineSeparator()).append("Arguments:").append(Config.getLineSeparator());
@@ -279,8 +282,8 @@ public final class ProcessedCommand<C extends Command> {
         return "ProcessedCommand{" +
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", options=" + options +
-                '}';
+ ", options=" + getOptions()
+                +                '}';
     }
 
     @Override
@@ -312,7 +315,8 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public boolean hasOptions() {
-        return getOptions() != null && getOptions().size() > 0;
+        List<ProcessedOption> opts = getOptions();
+        return opts != null && opts.size() > 0;
     }
 
     //will only return true if the optionName equals an option and it does
@@ -329,12 +333,12 @@ public final class ProcessedCommand<C extends Command> {
     }
 
     public void updateInvocationProviders(InvocationProviders invocationProviders) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             option.updateInvocationProviders(invocationProviders);
     }
 
     public void updateSettings(Settings settings) {
-        for(ProcessedOption option : options)
+        for (ProcessedOption option : getOptions())
             option.updateAnsiMode(settings.isAnsiConsole());
     }
 

--- a/src/main/java/org/jboss/aesh/cl/internal/ProcessedOption.java
+++ b/src/main/java/org/jboss/aesh/cl/internal/ProcessedOption.java
@@ -299,8 +299,8 @@ public final class ProcessedOption {
     }
 
     @SuppressWarnings("unchecked")
-    private Object doConvert(String inputValue, InvocationProviders invocationProviders, Object command,
-                             AeshContext aeshContext, boolean doValidation) throws OptionValidatorException {
+    public Object doConvert(String inputValue, InvocationProviders invocationProviders,
+            Object command, AeshContext aeshContext, boolean doValidation) throws OptionValidatorException {
         Object result = converter.convert(
         invocationProviders.getConverterProvider().enhanceConverterInvocation(
                 new AeshConverterInvocation(inputValue, aeshContext)));

--- a/src/main/java/org/jboss/aesh/cl/parser/AeshCommandLineParser.java
+++ b/src/main/java/org/jboss/aesh/cl/parser/AeshCommandLineParser.java
@@ -61,6 +61,10 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
         childParsers.add(commandLineParser);
     }
 
+    public List<CommandLineParser<? extends Command>> getChildParsers() {
+        return childParsers;
+    }
+
     @Override
     public void setChild(boolean child) {
         isChild = child;
@@ -68,9 +72,10 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
 
     @Override
     public List<String> getAllNames() {
-        if(isGroupCommand()) {
-            List<String> names = new ArrayList<>(childParsers.size());
-            for(CommandLineParser child : childParsers) {
+        if (isGroupCommand()) {
+            List<CommandLineParser<? extends Command>> parsers = getChildParsers();
+            List<String> names = new ArrayList<>(parsers.size());
+            for (CommandLineParser child : parsers) {
                 names.add(processedCommand.getName()+" "+child.getProcessedCommand().getName());
             }
             return names;
@@ -90,7 +95,7 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
     public CommandLineParser<? extends Command> getChildParser(String name) {
         if(!isGroupCommand())
             return null;
-        for(CommandLineParser clp : childParsers) {
+        for (CommandLineParser clp : getChildParsers()) {
             if(clp.getProcessedCommand().getName().equals(name))
                 return clp;
         }
@@ -100,7 +105,7 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
     @Override
     public List<CommandLineParser<? extends Command>> getAllChildParsers() {
         if(isGroupCommand())
-            return childParsers;
+            return getChildParsers();
         else
            return new ArrayList<>();
     }
@@ -131,14 +136,15 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
      */
     @Override
     public String printHelp() {
-        if(childParsers != null && childParsers.size() > 0) {
+        List<CommandLineParser<? extends Command>> parsers = getChildParsers();
+        if (parsers != null && parsers.size() > 0) {
             StringBuilder sb = new StringBuilder();
             sb.append(processedCommand.printHelp())
                     .append(Config.getLineSeparator())
                     .append(processedCommand.getName())
                     .append(" commands:")
                     .append(Config.getLineSeparator());
-            for(CommandLineParser child : childParsers)
+            for (CommandLineParser child : parsers)
                 sb.append("    ").append(child.getProcessedCommand().getName()).append(Config.getLineSeparator());
 
             return sb.toString();
@@ -541,14 +547,15 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
     public void clear() {
         processedCommand.clear();
         if(isGroupCommand()) {
-            for(CommandLineParser child : childParsers)
+            for (CommandLineParser child : getChildParsers())
                 child.getProcessedCommand().clear();
         }
     }
 
     @Override
     public boolean isGroupCommand() {
-        return childParsers != null && childParsers.size() > 0;
+        List<CommandLineParser<? extends Command>> parsers = getChildParsers();
+        return parsers != null && parsers.size() > 0;
     }
 
     @Override

--- a/src/main/java/org/jboss/aesh/console/command/map/MapCommand.java
+++ b/src/main/java/org/jboss/aesh/console/command/map/MapCommand.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.aesh.console.command.map;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.jboss.aesh.console.command.Command;
+import org.jboss.aesh.console.command.invocation.CommandInvocation;
+
+/**
+ *
+ * A command that stores option values in a map.
+ *
+ * @author jdenise@redhat.com
+ *
+ */
+public abstract class MapCommand<T extends CommandInvocation> implements Command<T> {
+
+    private final Map<String, Object> values = new HashMap<>();
+
+    public Object getValue(String name) {
+        return values.get(name);
+    }
+
+    public void setValue(String name, Object value) {
+        values.put(name, value);
+    }
+
+    public void resetValue(String name) {
+        values.remove(name);
+    }
+
+    public boolean contains(String name) {
+        return values.containsKey(name);
+    }
+
+    public Map<String, Object> getValues() {
+        return Collections.unmodifiableMap(values);
+    }
+}

--- a/src/main/java/org/jboss/aesh/console/command/map/MapCommandPopulator.java
+++ b/src/main/java/org/jboss/aesh/console/command/map/MapCommandPopulator.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.aesh.console.command.map;
+
+import java.util.Objects;
+import org.jboss.aesh.cl.CommandLine;
+import org.jboss.aesh.cl.internal.ProcessedOption;
+import org.jboss.aesh.cl.parser.CommandLineParserException;
+import org.jboss.aesh.cl.populator.CommandPopulator;
+import org.jboss.aesh.cl.validator.OptionValidatorException;
+import org.jboss.aesh.console.AeshContext;
+import org.jboss.aesh.console.InvocationProviders;
+import org.jboss.aesh.console.command.Command;
+
+/**
+ *
+ * Populator for MapCommand.
+ *
+ * @author jdenise@redhat.com
+ */
+class MapCommandPopulator implements CommandPopulator<Object, Command> {
+
+    private final MapCommand instance;
+
+    MapCommandPopulator(MapCommand instance) {
+        Objects.requireNonNull(instance);
+        this.instance = instance;
+    }
+
+    @Override
+    public void populateObject(CommandLine<Command> line,
+            InvocationProviders invocationProviders,
+            AeshContext aeshContext, boolean validate)
+            throws CommandLineParserException, OptionValidatorException {
+        if (line.hasParserError()) {
+            throw line.getParserException();
+        }
+        for (ProcessedOption option : line.getParser().getProcessedCommand().getOptions()) {
+            if (line.hasOption(option.getName())) {
+                ProcessedOption o = line.getOption(option.getName());
+                instance.setValue(o.getName(),
+                        o.doConvert(o.getValue(), invocationProviders,
+                                instance, aeshContext, validate));
+            } else if (option.getDefaultValues().size() > 0) {
+                instance.setValue(option.getName(),
+                        option.doConvert(option.getDefaultValues().get(0),
+                                invocationProviders, instance, aeshContext,
+                                validate));
+            } else {
+                instance.resetValue(option.getName());
+            }
+        }
+        if ((line.getArgument() != null && line.getArgument().getValues().size() > 0)
+                || (line.getParser().getProcessedCommand().getArgument() != null
+                && line.getParser().getProcessedCommand().getArgument().
+                getDefaultValues().size() > 0)) {
+            Object val = line.getArgument().getValue();
+            if (val == null) {
+                instance.setValue(line.getArgument().getName(),
+                        line.getOption(line.getArgument().getName()).
+                        doConvert(line.getArgument().getDefaultValues().get(0),
+                                invocationProviders, instance, aeshContext,
+                                validate));
+            } else {
+                instance.setValue(line.getArgument().getName(),
+                        line.getOption(line.getArgument().getName()).
+                        doConvert(line.getArgument().getValue(),
+                                invocationProviders, instance, aeshContext,
+                                validate));
+            }
+            line.getArgument().injectValueIntoField(getObject(),
+                    invocationProviders, aeshContext, validate);
+        } else if (line.getArgument() != null) {
+            // Must be named
+            instance.resetValue(line.getArgument().getName());
+        }
+    }
+
+    @Override
+    public Object getObject() {
+        return instance;
+    }
+}

--- a/src/main/java/org/jboss/aesh/console/command/map/MapProcessedCommandBuilder.java
+++ b/src/main/java/org/jboss/aesh/console/command/map/MapProcessedCommandBuilder.java
@@ -1,0 +1,207 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aesh.console.command.map;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import org.jboss.aesh.cl.parser.CommandLineParserException;
+import java.util.List;
+import org.jboss.aesh.cl.internal.ProcessedCommand;
+import org.jboss.aesh.cl.internal.ProcessedOption;
+import org.jboss.aesh.cl.parser.OptionParserException;
+import org.jboss.aesh.cl.populator.CommandPopulator;
+import org.jboss.aesh.cl.result.NullResultHandler;
+import org.jboss.aesh.cl.result.ResultHandler;
+import org.jboss.aesh.cl.validator.CommandValidator;
+import org.jboss.aesh.cl.validator.NullCommandValidator;
+import org.jboss.aesh.util.ReflectionUtil;
+
+public class MapProcessedCommandBuilder {
+
+    private static final ProcessedOptionProvider EMPTY_PROVIDER
+            = new ProcessedOptionProvider() {
+        @Override
+        public List<ProcessedOption> getOptions() {
+            return Collections.emptyList();
+        }
+    };
+    private static class MapProcessedCommand extends ProcessedCommand<MapCommand> {
+        private final ProcessedOptionProvider provider;
+        public MapProcessedCommand(String name,
+                MapCommand command,
+                String description,
+                CommandValidator validator,
+                ResultHandler resultHandler,
+                ProcessedOption argument,
+                List<ProcessedOption> options,
+                CommandPopulator populator,
+                ProcessedOptionProvider provider) throws OptionParserException {
+            super(name, command, description, validator, resultHandler, argument,
+                    options, populator);
+            this.provider = provider == null ? EMPTY_PROVIDER : provider;
+        }
+
+        @Override
+        public List<ProcessedOption> getOptions() {
+            List<ProcessedOption> allOptions = new ArrayList<>(super.getOptions());
+            // During super construction, properties are retrieved. In this case
+            // provider is not already set.
+            if (provider != null) {
+                allOptions.addAll(provider.getOptions());
+            }
+            return allOptions;
+        }
+    }
+
+    public interface ProcessedOptionProvider {
+
+        List<ProcessedOption> getOptions();
+    }
+    private ProcessedOptionProvider provider;
+    private String name;
+    private String description;
+    private CommandValidator<?> validator;
+    private ResultHandler resultHandler;
+    private ProcessedOption argument;
+    private final List<ProcessedOption> options;
+    private CommandPopulator populator;
+    private MapCommand command;
+
+    public MapProcessedCommandBuilder() {
+        options = new ArrayList<>();
+    }
+
+    public MapProcessedCommandBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder description(String usage) {
+        this.description = usage;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder optionProvider(ProcessedOptionProvider provider) {
+        this.provider = provider;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder argument(ProcessedOption argument) {
+        this.argument = argument;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder validator(CommandValidator<?> validator) {
+        this.validator = validator;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder validator(Class<? extends CommandValidator> validator) {
+        this.validator = initValidator(validator);
+        return this;
+    }
+
+    private CommandValidator initValidator(Class<? extends CommandValidator> validator) {
+        if (validator != null && !validator.equals(NullCommandValidator.class)) {
+            return ReflectionUtil.newInstance(validator);
+        } else {
+            return new NullCommandValidator();
+        }
+    }
+
+    public MapProcessedCommandBuilder resultHandler(Class<? extends ResultHandler> resultHandler) {
+        this.resultHandler = initResultHandler(resultHandler);
+        return this;
+    }
+
+    private ResultHandler initResultHandler(Class<? extends ResultHandler> resultHandler) {
+        if (resultHandler != null && !resultHandler.equals(NullResultHandler.class)) {
+            return ReflectionUtil.newInstance(resultHandler);
+        } else {
+            return new NullResultHandler();
+        }
+    }
+
+    public MapProcessedCommandBuilder resultHandler(ResultHandler resultHandler) {
+        this.resultHandler = resultHandler;
+        return this;
+    }
+
+    /**
+     * By default a map populator will inject values in the MapCommand
+     *
+     * @param populator
+     * @return
+     */
+    public MapProcessedCommandBuilder populator(CommandPopulator populator) {
+        this.populator = populator;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder command(MapCommand command) {
+        this.command = command;
+        return this;
+    }
+
+    public MapProcessedCommandBuilder command(Class<? extends MapCommand> command) {
+        this.command = ReflectionUtil.newInstance(command);
+        return this;
+    }
+
+    public MapProcessedCommandBuilder addOption(ProcessedOption option) {
+        this.options.add(option);
+        return this;
+    }
+
+    public MapProcessedCommandBuilder addOptions(List<ProcessedOption> options) {
+        if (options != null) {
+            this.options.addAll(options);
+        }
+        return this;
+    }
+
+    public ProcessedCommand create() throws CommandLineParserException {
+        if (name == null || name.length() < 1) {
+            throw new CommandLineParserException("The parameter name must be defined");
+        }
+
+        if (validator == null) {
+            validator = new NullCommandValidator();
+        }
+
+        if (resultHandler == null) {
+            resultHandler = new NullResultHandler();
+        }
+
+        if (populator == null) {
+            populator = new MapCommandPopulator(command);
+        }
+
+        return new MapProcessedCommand(name,
+                command,
+                description,
+                validator,
+                resultHandler,
+                argument,
+                options,
+                populator,
+                provider);
+    }
+}


### PR DESCRIPTION
The idea is to introduce a subinterface of Command<T>, the MapCommand<T>, that stores the injected options into a Map. This allows user to define Command dynamically, outside of any need for a Class to describe the Command/Options.

In addition this change allows to compute options (Thanks to the ProcessedOptionprovider interface) and sub commands on the fly.

Usage example:
// Create the Command that will receive command execution
MapCommand<CliCommandInvocation> com = new MapCommand<>() {
public CommandResult execute(CliCommandInvocation commandInvocation) {
    String value = getValue("option1");   
     ....
};

// Create a ProcessedCommand that describes the Command. Can be used with a set of known options
// or with a ProcessedOptionProvider
ProcessedCommand command = new MapProcessedCommandBuilder().name("mycommand").command(com).option(<option1>).optionProvider(new MyOptionProvider()).create();

// Wrap the command in a container and add it to the registry
reg.addCommand(new AeshCommandContainer(command));

