### PR TITLE
Fix for AESH-388

### DIFF
--- a/src/main/java/AeshExample.java
+++ b/src/main/java/AeshExample.java
@@ -181,7 +181,7 @@ public class AeshExample {
     }
 
     private static class HideActivator implements CommandActivator {
-        public boolean isActivated() {
+        public boolean isActivated(ProcessedCommand cmd) {
             return false;
         }
     }

--- a/src/main/java/org/jboss/aesh/cl/activation/CommandActivator.java
+++ b/src/main/java/org/jboss/aesh/cl/activation/CommandActivator.java
@@ -19,6 +19,8 @@
  */
 package org.jboss.aesh.cl.activation;
 
+import org.jboss.aesh.cl.internal.ProcessedCommand;
+
 /**
  * @author jdenise@redhat.com
  */
@@ -29,5 +31,5 @@ public interface CommandActivator {
      *
      * @return
      */
-    boolean isActivated();
+    boolean isActivated(ProcessedCommand command);
 }

--- a/src/main/java/org/jboss/aesh/cl/activation/NullCommandActivator.java
+++ b/src/main/java/org/jboss/aesh/cl/activation/NullCommandActivator.java
@@ -19,12 +19,14 @@
  */
 package org.jboss.aesh.cl.activation;
 
+import org.jboss.aesh.cl.internal.ProcessedCommand;
+
 /**
  * @author jdenise@redhat.com
  */
 public class NullCommandActivator implements CommandActivator {
     @Override
-    public boolean isActivated() {
+    public boolean isActivated(ProcessedCommand command) {
         return true;
     }
 }

--- a/src/main/java/org/jboss/aesh/cl/parser/ParserGenerator.java
+++ b/src/main/java/org/jboss/aesh/cl/parser/ParserGenerator.java
@@ -44,7 +44,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import org.jboss.aesh.console.command.GroupCommand;
 import org.jboss.aesh.console.command.activator.AeshCommandActivatorProvider;
 
 /**
@@ -106,10 +108,18 @@ public class ParserGenerator {
                             .processedCommand(processedGroupCommand)
                             .create());
 
-
-            for(Class<? extends Command> groupClazz : groupCommand.groupCommands()) {
-                Command groupInstance = ReflectionUtil.newInstance(groupClazz);
+            if (commandObject instanceof GroupCommand) {
+                List<Command> commands = ((GroupCommand) commandObject).getCommands();
+                if (commands != null) {
+                    for (Command sub : commands) {
+                        groupContainer.addChild(ParserGenerator.doGenerateCommandLineParser(sub));
+                    }
+                }
+            } else {
+                for (Class<? extends Command> groupClazz : groupCommand.groupCommands()) {
+                    Command groupInstance = ReflectionUtil.newInstance(groupClazz);
                     groupContainer.addChild(ParserGenerator.doGenerateCommandLineParser(groupInstance));
+                }
             }
 
             return groupContainer;

--- a/src/main/java/org/jboss/aesh/console/command/GroupCommand.java
+++ b/src/main/java/org/jboss/aesh/console/command/GroupCommand.java
@@ -20,11 +20,12 @@
 package org.jboss.aesh.console.command;
 
 import java.util.List;
+import org.jboss.aesh.console.command.invocation.CommandInvocation;
 
 /**
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
  */
-public interface GroupCommand extends Command {
+public interface GroupCommand<T extends CommandInvocation> extends Command<T> {
 
     List<Command> getCommands();
 

--- a/src/main/java/org/jboss/aesh/console/command/registry/MutableCommandRegistry.java
+++ b/src/main/java/org/jboss/aesh/console/command/registry/MutableCommandRegistry.java
@@ -84,7 +84,7 @@ public class MutableCommandRegistry implements CommandRegistry {
         for(CommandContainer<Command> command : registry.values()) {
             ProcessedCommand com = command.getParser().getProcessedCommand();
             if(com.getName().startsWith(co.getBuffer()) &&
-                    com.getActivator().isActivated()) {
+                com.getActivator().isActivated(com)) {
                 if(command.getParser().isGroupCommand()) {
                     LOGGER.info("command is a group command");
                     //if we dont have any arguments we'll add the child commands as well
@@ -102,12 +102,12 @@ public class MutableCommandRegistry implements CommandRegistry {
             }
             else if(command.getParser().isGroupCommand() &&
                     co.getBuffer().startsWith(com.getName()) &&
-                    com.getActivator().isActivated()) {
+                    com.getActivator().isActivated(com)) {
                 String groupLine = Parser.trimInFront( co.getBuffer().substring(com.getName().length()));
                 int diff = co.getBuffer().length() - groupLine.length();
                 for(CommandLineParser child : command.getParser().getAllChildParsers()) {
                     if(child.getProcessedCommand().getName().startsWith(groupLine) &&
-                            child.getProcessedCommand().getActivator().isActivated())
+                        child.getProcessedCommand().getActivator().isActivated(child.getProcessedCommand()))
                         names.add(co.getBuffer().substring(0, diff) + child.getProcessedCommand().getName());
                 }
             }

--- a/src/test/java/org/jboss/aesh/console/aesh/AeshCommandCompletionTest.java
+++ b/src/test/java/org/jboss/aesh/console/aesh/AeshCommandCompletionTest.java
@@ -335,7 +335,7 @@ public class AeshCommandCompletionTest {
 
         static boolean activated;
         @Override
-        public boolean isActivated() {
+        public boolean isActivated(ProcessedCommand cmd) {
             return activated;
         }
     }


### PR DESCRIPTION
Take into account commands that implements GroupCommand. Make CommandActivator to take ProcessedCommand as parameter, it allows to share state between Command and Activator (same pattern as OptionActivator).
