### PR TITLE
[AESH-390] Fix issue that Alias --help completion is always added if word is empty.

### DIFF
--- a/src/main/java/org/jboss/aesh/console/alias/AliasCompletion.java
+++ b/src/main/java/org/jboss/aesh/console/alias/AliasCompletion.java
@@ -61,7 +61,7 @@ public class AliasCompletion implements Completion {
                 completeOperation.getBuffer().startsWith(UNALIAS_SPACE)) {
             String word = Parser.findCurrentWordFromCursor(completeOperation.getBuffer(), completeOperation.getCursor());
             completeOperation.addCompletionCandidates(manager.findAllMatchingNames(word));
-            if (HELP.startsWith(word)) {
+            if (!word.isEmpty() && HELP.startsWith(word)) {
                 completeOperation.addCompletionCandidate(HELP);
             }
             completeOperation.setOffset(completeOperation.getCursor()-word.length());


### PR DESCRIPTION
see https://issues.jboss.org/browse/AESH-390