### PR TITLE
Fix for AESH-429. Change running flag at the end of close

### DIFF
--- a/src/main/java/org/jboss/aesh/console/Console.java
+++ b/src/main/java/org/jboss/aesh/console/Console.java
@@ -447,8 +447,7 @@ public class Console {
      * @throws IOException stream
      */
     private synchronized void doStop() throws IOException {
-        if(running) {
-            running = false;
+        if (running) {
             if(initiateStop)
                 initiateStop = false;
 
@@ -483,6 +482,10 @@ public class Console {
 
         getTerminal().close();
         getTerminal().reset();
+
+        if (running) {
+            running = false;
+        }
     }
 
     /**


### PR DESCRIPTION
In order to have running to reflect the fact that the console is fully closed.
