### PR TITLE
added nexus repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ test {
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        url "http://repository.jboss.org/nexus/content/groups/public/"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Need the nexus repo to build if you don't have aesh-readline in your local repo.