### PR TITLE
Intial support for Pipe operator and injection

### DIFF
--- a/src/main/java/org/aesh/command/impl/operator/AppendOutputRedirectionOperator.java
+++ b/src/main/java/org/aesh/command/impl/operator/AppendOutputRedirectionOperator.java
@@ -24,7 +24,7 @@ import org.aesh.console.AeshContext;
  */
 public class AppendOutputRedirectionOperator implements ConfigurationOperator {
 
-    private class OutputDelegateImpl extends OutputDelegate {
+    private class OutputDelegateImpl extends FileOutputDelegate {
 
         private OutputDelegateImpl(String file) throws IOException {
             super(context, file);

--- a/src/main/java/org/aesh/command/impl/operator/EndOperator.java
+++ b/src/main/java/org/aesh/command/impl/operator/EndOperator.java
@@ -19,7 +19,6 @@
  */
 package org.aesh.command.impl.operator;
 
-import java.util.concurrent.ExecutionException;
 import org.aesh.command.Command;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
@@ -33,24 +32,12 @@ public class EndOperator<T extends CommandInvocation> implements ExecutableOpera
 
     private Command<T> executable;
 
-    private DataProvider dataProvider;
-
     public EndOperator() {
 
     }
 
     @Override
     public CommandResult execute(T ic) throws CommandException, InterruptedException {
-        // XXX JFDENISE, do something with Data provider if not null.
-        // Such as introspect command to findout the target.
-        if (dataProvider != null) {
-            try {
-                String data = dataProvider.getData().get();
-                // XXX TODO
-            } catch (ExecutionException ex) {
-                throw new CommandException(ex);
-            }
-        }
         return executable.execute(ic);
     }
 
@@ -58,10 +45,4 @@ public class EndOperator<T extends CommandInvocation> implements ExecutableOpera
     public void setCommand(Command<T> executable) {
         this.executable = executable;
     }
-
-    @Override
-    public void setDataProvider(DataProvider dataProvider) {
-        this.dataProvider = dataProvider;
-    }
-
 }

--- a/src/main/java/org/aesh/command/impl/operator/ExecutableOperator.java
+++ b/src/main/java/org/aesh/command/impl/operator/ExecutableOperator.java
@@ -29,6 +29,4 @@ import org.aesh.command.invocation.CommandInvocation;
  */
 public interface ExecutableOperator<T extends CommandInvocation> extends Operator, Executable<T> {
     void setCommand(Command<T> exec);
-
-    void setDataProvider(DataProvider dataProvider);
 }

--- a/src/main/java/org/aesh/command/impl/operator/FileOutputDelegate.java
+++ b/src/main/java/org/aesh/command/impl/operator/FileOutputDelegate.java
@@ -19,12 +19,33 @@
  */
 package org.aesh.command.impl.operator;
 
-import java.io.BufferedInputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import org.aesh.console.AeshContext;
 
 /**
+ * Output to a file.
  *
  * @author jdenise@redhat.com
  */
-public interface DataProvider {
-    BufferedInputStream getData();
+public abstract class FileOutputDelegate extends OutputDelegate {
+    private final File outputFile;
+
+    protected FileOutputDelegate(AeshContext context, String file) {
+        Objects.requireNonNull(file);
+        File f = new File(file);
+        if (!f.isAbsolute()) {
+            f = new File(context.getCurrentWorkingDirectory().getAbsolutePath(), file);
+        }
+        outputFile = f;
+    }
+
+    @Override
+    protected BufferedWriter buildWriter() throws IOException {
+        return buildWriter(outputFile);
+    }
+
+    protected abstract BufferedWriter buildWriter(File f) throws IOException;
 }

--- a/src/main/java/org/aesh/command/impl/operator/OutputDelegate.java
+++ b/src/main/java/org/aesh/command/impl/operator/OutputDelegate.java
@@ -20,10 +20,7 @@
 package org.aesh.command.impl.operator;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
-import org.aesh.console.AeshContext;
 import org.aesh.util.Parser;
 
 /**
@@ -33,22 +30,15 @@ import org.aesh.util.Parser;
 public abstract class OutputDelegate {
 
     private BufferedWriter writer;
-    private final File outputFile;
-    protected OutputDelegate(AeshContext context, String file) {
-        Objects.requireNonNull(file);
-        File f = new File(file);
-        if (!f.isAbsolute()) {
-            f = new File(context.getCurrentWorkingDirectory().getAbsolutePath(), file);
-        }
-        outputFile = f;
+    protected OutputDelegate() {
     }
 
-    protected abstract BufferedWriter buildWriter(File f) throws IOException;
+    protected abstract BufferedWriter buildWriter() throws IOException;
 
     public void write(String msg) throws IOException {
         msg = Parser.stripAwayAnsiCodes(msg);
         if (writer == null) {
-            writer = buildWriter(outputFile);
+            writer = buildWriter();
         }
         writer.append(msg);
         writer.flush();

--- a/src/main/java/org/aesh/command/impl/operator/OutputRedirectionOperator.java
+++ b/src/main/java/org/aesh/command/impl/operator/OutputRedirectionOperator.java
@@ -33,7 +33,7 @@ import org.aesh.console.AeshContext;
  */
 public class OutputRedirectionOperator implements ConfigurationOperator {
 
-    private class OutputDelegateImpl extends OutputDelegate {
+    private class OutputDelegateImpl extends FileOutputDelegate {
 
         private OutputDelegateImpl(String file) throws IOException {
             super(context, file);

--- a/src/main/java/org/aesh/command/invocation/CommandInvocationConfiguration.java
+++ b/src/main/java/org/aesh/command/invocation/CommandInvocationConfiguration.java
@@ -19,6 +19,9 @@
  */
 package org.aesh.command.invocation;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import org.aesh.command.impl.operator.DataProvider;
 import org.aesh.command.impl.operator.OutputDelegate;
 import org.aesh.console.AeshContext;
 
@@ -28,16 +31,26 @@ import org.aesh.console.AeshContext;
  */
 public class CommandInvocationConfiguration {
 
+    private static final BufferedInputStream EMPTY_INPUT
+            = new BufferedInputStream(new ByteArrayInputStream(new byte[0]));
+    private static final DataProvider EMPTY_DATA_PROVIDER = () -> {
+        return EMPTY_INPUT;
+    };
     private final OutputDelegate delegate;
     private final AeshContext context;
-
+    private final DataProvider dataProvider;
     public CommandInvocationConfiguration(AeshContext context) {
-        this(context, null);
+        this(context, null, null);
     }
 
     public CommandInvocationConfiguration(AeshContext context, OutputDelegate delegate) {
+        this(context, delegate, null);
+    }
+
+    public CommandInvocationConfiguration(AeshContext context, OutputDelegate delegate, DataProvider dataProvider) {
         this.context = context;
         this.delegate = delegate;
+        this.dataProvider = dataProvider == null ? EMPTY_DATA_PROVIDER : dataProvider;
     }
 
     public OutputDelegate getOutputRedirection() {
@@ -46,5 +59,9 @@ public class CommandInvocationConfiguration {
 
     public AeshContext getAeshContext() {
         return context;
+    }
+
+    public BufferedInputStream getPipedData() {
+        return dataProvider.getData();
     }
 }

--- a/src/main/java/org/aesh/command/operator/OperatorType.java
+++ b/src/main/java/org/aesh/command/operator/OperatorType.java
@@ -27,28 +27,28 @@ import java.util.Set;
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
  */
 public enum OperatorType {
-    PIPE("|"),
+    PIPE("|", false, true),
     PIPE_AND_ERROR("|&"),
-    REDIRECT_OUT(">", true),
-    REDIRECT_OUT_ERROR("2>", true),
-    REDIRECT_IN("<", true),
+    REDIRECT_OUT(">", true, true),
+    REDIRECT_OUT_ERROR("2>", true, true),
+    REDIRECT_IN("<", true, true),
     END(";"),
-    APPEND_OUT(">>", true),
-    APPEND_OUT_ERROR("2>>", true),
-    REDIRECT_OUT_ALL("2>&1", true),
-    AMP("&", true),
-    AND("&&", true),
-    OR("||", true),
+    APPEND_OUT(">>", true, true),
+    APPEND_OUT_ERROR("2>>", true, true),
+    REDIRECT_OUT_ALL("2>&1", true, true),
+    AMP("&", true, true),
+    AND("&&", true, true),
+    OR("||", true, true),
     NONE("");
 
     private final String value;
     private final boolean hasArgument;
     private final boolean isConfiguration;
 
-    OperatorType(String c, boolean hasArgument) {
+    OperatorType(String c, boolean hasArgument, boolean isConfiguration) {
         value = c;
         this.hasArgument = hasArgument;
-        this.isConfiguration = true;
+        this.isConfiguration = isConfiguration;
     }
 
     OperatorType(String c) {


### PR DESCRIPTION
I am treating the Pipe operator as a dual operator. It is similar to the OutputRedirection in the sense that it should trap the output of the previous command, but in addition this operator is executable, it means that the previous command as to be executed when encountering the '|', no need for ';' operator.

So the pipe operator will configure the CommandInvocation with an OutputDelegate that keeps the output from the previous command in memory array.

Once executed, the output from the previous command is available from the CommandInvocation, making next command to be able to use it.
The mesh-extensions grep command has been re-implemented on top of it and works as expected.