### PR TITLE
Lazy CommandInvocation creation. Expose original line from cursor

### DIFF
--- a/src/main/java/org/aesh/parser/LineParser.java
+++ b/src/main/java/org/aesh/parser/LineParser.java
@@ -182,7 +182,7 @@ public class LineParser {
                     builder.append(c);
 
                 //if current operator is set, we need to handle index/prev specially
-                if(currentOperator != OperatorType.NONE) {
+                if (currentOperator != null && currentOperator != OperatorType.NONE) {
                    index = index + currentOperator.value().length();
                    prev = text.charAt(index-1);
                    //we need to reset operator

--- a/src/main/java/org/aesh/parser/ParsedLineIterator.java
+++ b/src/main/java/org/aesh/parser/ParsedLineIterator.java
@@ -37,6 +37,10 @@ public class ParsedLineIterator {
         this.parsedLine = parsedLine;
     }
 
+    public String getOriginalLine() {
+        return parsedLine.line();
+    }
+
     /**
      * @return true if there is a next word
      */

--- a/src/test/java/org/aesh/parser/LineParserTest.java
+++ b/src/test/java/org/aesh/parser/LineParserTest.java
@@ -382,6 +382,10 @@ public class LineParserTest {
          assertEquals("test1.txt", lines.get(1).words().get(0).word());
          assertEquals("foo", lines.get(2).words().get(0).word());
 
+         lines = lineParser.parseLine(" :read-resource", 15, true, operators);
+         assertEquals(":read-resource", lines.get(0).words().get(0).word());
+
+         // Still failing.
          lines = lineParser.parseLine("foo get >> test1.txt; foo get >> test1.txt", 19, true, operators);
          assertEquals("foo", lines.get(0).words().get(0).word());
          assertEquals("test1.txt", lines.get(1).words().get(0).word());


### PR DESCRIPTION
- Lazy creation of the CommandInvocation. 
Imagine 2 commands on the same line, first one change in some way the execution context. When the second command is executed, it must have its CommandInvocation in sync with the changes done by the previous command.
The CommandInvocation is now built when retrieved (just prior to execution).

- Expose the original line from the parser iterator. 
