### PR TITLE
Operator unit test. Makes SettingsBuilder operator aware

### DIFF
--- a/src/main/java/org/aesh/command/AeshCommandRuntimeBuilder.java
+++ b/src/main/java/org/aesh/command/AeshCommandRuntimeBuilder.java
@@ -152,6 +152,7 @@ public class AeshCommandRuntimeBuilder {
             c.commandActivatorProvider = settings.commandActivatorProvider();
             c.registry = settings.commandRegistry();
             c.ctx = settings.aeshContext();
+            c.operators = settings.operatorParserEnabled() ? EnumSet.allOf(OperatorType.class) : null;
         });
     }
 

--- a/src/main/java/org/aesh/command/CommandResolver.java
+++ b/src/main/java/org/aesh/command/CommandResolver.java
@@ -32,4 +32,6 @@ public interface CommandResolver<C extends Command> {
 
     CommandContainer<C> resolveCommand(String line) throws CommandNotFoundException;
 
+    CommandContainer<C> resolveCommand(String name, String line) throws CommandNotFoundException;
+
 }

--- a/src/main/java/org/aesh/command/impl/AeshCommandResolver.java
+++ b/src/main/java/org/aesh/command/impl/AeshCommandResolver.java
@@ -50,6 +50,12 @@ public class AeshCommandResolver<C extends Command> implements CommandResolver<C
         return getCommand(lineParser.parseLine(line), line);
     }
 
+    @Override
+    public CommandContainer<C> resolveCommand(String name, String line) throws CommandNotFoundException {
+        return getCommand(name, line);
+    }
+
+
     /**
      * try to return the command in the given registry if the given registry do not find the command, check if we have a
      * internal registry and if its there.
@@ -82,6 +88,5 @@ public class AeshCommandResolver<C extends Command> implements CommandResolver<C
             return registry.getCommandByAlias(commandName);
         }
     }
-
 
 }

--- a/src/main/java/org/aesh/command/impl/AeshCommandRuntime.java
+++ b/src/main/java/org/aesh/command/impl/AeshCommandRuntime.java
@@ -220,7 +220,7 @@ public class AeshCommandRuntime<C extends Command, CI extends CommandInvocation>
             return null;
         }
         String opName = aeshLine.words().get(0).word();
-        CommandContainer<C> container = registry.getCommand(opName, commandLine);
+        CommandContainer container = commandResolver.resolveCommand(opName, commandLine);
         if (container == null) {
             throw new CommandNotFoundException("No command handler for '" + opName + "'.");
         }

--- a/src/main/java/org/aesh/console/settings/SettingsBuilder.java
+++ b/src/main/java/org/aesh/console/settings/SettingsBuilder.java
@@ -247,6 +247,10 @@ public class SettingsBuilder {
         return apply(c -> c.settings.setConnection(connection));
     }
 
+    public SettingsBuilder enableOperatorParser(boolean enabled) {
+        return apply(c -> c.settings.enableOperatorParser(enabled));
+    }
+
     public Settings build() {
         if(settings.logging())
             LoggerUtil.doLog();

--- a/src/test/java/org/aesh/console/aesh/AeshCommandEndOperatorTest.java
+++ b/src/test/java/org/aesh/console/aesh/AeshCommandEndOperatorTest.java
@@ -32,7 +32,6 @@ import org.aesh.console.settings.SettingsBuilder;
 import org.aesh.readline.ReadlineConsole;
 import org.aesh.tty.TestConnection;
 import org.aesh.util.Config;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -44,7 +43,6 @@ import static org.junit.Assert.assertEquals;
  *
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
  */
-@Ignore
 public class AeshCommandEndOperatorTest {
 
     private static int counter = 0;
@@ -60,6 +58,7 @@ public class AeshCommandEndOperatorTest {
 
         Settings settings = SettingsBuilder.builder()
                 .commandRegistry(registry)
+                .enableOperatorParser(true)
                 .connection(connection)
                 .setPersistExport(false)
                 .logging(true)
@@ -68,8 +67,7 @@ public class AeshCommandEndOperatorTest {
         ReadlineConsole console = new ReadlineConsole(settings);
         console.start();
 
-        connection.read("foo ;bar --info yup; foo"+ Config.getLineSeparator());
-        //outputStream.flush();
+        connection.read("foo ;bar --info yup; foo" + Config.getLineSeparator());
         Thread.sleep(100);
         assertEquals(3, counter);
 


### PR DESCRIPTION
Make settingsBuilder aware of operators.
Updated tests to unignore them. PipeTest has been reversed. The command after the pipe not before the pipe checks for available data.
