### PR TITLE
[AESH-435] restrict maxLength to termial width.

### DIFF
--- a/src/main/java/org/jboss/aesh/parser/Parser.java
+++ b/src/main/java/org/jboss/aesh/parser/Parser.java
@@ -78,11 +78,17 @@ public class Parser {
             termWidth = 80; // setting it to default
 
         int maxLength = 0;
-        for (String completion : displayList)
+        for (String completion : displayList){
+            if(completion.length() > termWidth){
+                maxLength = termWidth;
+                break;
+            }
             if (completion.length() > maxLength)
                 maxLength = completion.length();
+        }
 
-        maxLength = maxLength + 2; // adding two spaces for better readability
+        if (maxLength + 2 <= termWidth)
+            maxLength = maxLength + 2; // adding two spaces for better readability
         int numColumns = termWidth / maxLength;
         if (numColumns > displayList.size()) // we dont need more columns than items
             numColumns = displayList.size();

--- a/src/test/java/org/jboss/aesh/parser/ParserTest.java
+++ b/src/test/java/org/jboss/aesh/parser/ParserTest.java
@@ -264,10 +264,14 @@ public class ParserTest {
     @Test
     public void testFormatDisplayList() {
         List<String> list = new ArrayList<>();
-        String s1 = "this is a loooooong string thats longer than the terminal width";
+        String s1 = "this is a short string thats shorter than the terminal width";
         list.add(s1);
+        assertEquals(s1 + "  " + Config.getLineSeparator(), Parser.formatDisplayList(list, 80, 120));
 
-        assertEquals(s1 + "  " + Config.getLineSeparator(), Parser.formatDisplayList(list, 20, 20));
+        String s2 = "this is a loooooong string thats longer than the terminal width";
+        list.clear();
+        list.add(s2);
+        assertEquals(s2 + Config.getLineSeparator(), Parser.formatDisplayList(list, 20, 20));
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/AESH-435

In case that list element is longer than terminal width, Parser.formatDisplayList() set maxLength to longest element length. This will make all other short elements hold unnecessary lines. This makes an unfriendly output format as attached in issue.

This is for 0.66.+ I don't see same Parser.java in master branch.