### PR TITLE
[AESH-435] expose terminal height and width.

### DIFF
--- a/src/main/java/org/jboss/aesh/terminal/POSIXTerminal.java
+++ b/src/main/java/org/jboss/aesh/terminal/POSIXTerminal.java
@@ -134,7 +134,8 @@ public class POSIXTerminal extends AbstractTerminal {
         return size;
     }
 
-    private int getHeight() {
+    @Override
+    public int getHeight() {
         int height = 0;
         try {
             height = getTerminalProperty("rows");
@@ -150,7 +151,8 @@ public class POSIXTerminal extends AbstractTerminal {
         return height;
     }
 
-    private int getWidth() {
+    @Override
+    public int getWidth() {
         int width = 0;
         try {
             width = getTerminalProperty("columns");

--- a/src/main/java/org/jboss/aesh/terminal/Terminal.java
+++ b/src/main/java/org/jboss/aesh/terminal/Terminal.java
@@ -70,4 +70,8 @@ public interface Terminal extends Closeable {
      * @param output stream
      */
     void changeOutputStream(PrintStream output);
+
+    int getHeight();
+
+    int getWidth();
 }

--- a/src/main/java/org/jboss/aesh/terminal/TestTerminal.java
+++ b/src/main/java/org/jboss/aesh/terminal/TestTerminal.java
@@ -142,4 +142,13 @@ public class TestTerminal implements Terminal, Shell {
         outWriter = output;
     }
 
+    @Override
+    public int getHeight() {
+        return 24;
+    }
+
+    @Override
+    public int getWidth() {
+        return 80;
+    }
 }

--- a/src/main/java/org/jboss/aesh/terminal/WindowsTerminal.java
+++ b/src/main/java/org/jboss/aesh/terminal/WindowsTerminal.java
@@ -105,7 +105,8 @@ public class WindowsTerminal extends AbstractTerminal {
         return input.hasInput();
     }
 
-    private int getHeight() {
+    @Override
+    public int getHeight() {
         int height;
         height = WindowsSupport.getWindowsTerminalHeight();
         ttyPropsLastFetched = System.currentTimeMillis();
@@ -117,7 +118,8 @@ public class WindowsTerminal extends AbstractTerminal {
         return height;
     }
 
-    private int getWidth() {
+    @Override
+    public int getWidth() {
         int width;
         width = WindowsSupport.getWindowsTerminalWidth();
         ttyPropsLastFetched = System.currentTimeMillis();


### PR DESCRIPTION
This helps in CLI non interactive mode to get values of terminal where it launches non interactive mode, without a console instance.

https://issues.jboss.org/browse/AESH-435

related change in CLI is https://github.com/soul2zimate/wildfly-core/commits/WFCORE-2812-non-interactive