### PR TITLE
More advanced support for operator combinations

### DIFF
--- a/src/main/java/org/aesh/command/impl/operator/PipeOperator.java
+++ b/src/main/java/org/aesh/command/impl/operator/PipeOperator.java
@@ -54,7 +54,7 @@ public class PipeOperator extends EndOperator implements
     @Override
     public CommandInvocationConfiguration getConfiguration() throws IOException {
         if (config == null) {
-            config = new CommandInvocationConfiguration(context, new OutputDelegateImpl(), this);
+            config = new CommandInvocationConfiguration(context, new OutputDelegateImpl(), null);
         }
         return config;
     }

--- a/src/main/java/org/aesh/command/invocation/CommandInvocationConfiguration.java
+++ b/src/main/java/org/aesh/command/invocation/CommandInvocationConfiguration.java
@@ -43,7 +43,7 @@ public class CommandInvocationConfiguration {
     private InputDelegate inputDelegate;
 
     public CommandInvocationConfiguration(AeshContext context) {
-        this.context = context;
+        this(context, null, null, null);
     }
 
     public CommandInvocationConfiguration(AeshContext context, OutputDelegate outputDelegate) {
@@ -51,26 +51,26 @@ public class CommandInvocationConfiguration {
     }
 
     public CommandInvocationConfiguration(AeshContext context, DataProvider dataProvider) {
+        this(context, null, null, dataProvider);
+    }
+
+    public CommandInvocationConfiguration(AeshContext context, OutputDelegate outputDelegate, InputDelegate inputDelegate, DataProvider dataProvider) {
         this.context = context;
-        this.dataProvider = dataProvider;
+        this.outputDelegate = outputDelegate;
+        this.inputDelegate = inputDelegate;
+        this.dataProvider = dataProvider == null ? EMPTY_DATA_PROVIDER : dataProvider;
     }
 
     public CommandInvocationConfiguration(AeshContext context, OutputDelegate outputDelegate, DataProvider dataProvider) {
-        this.context = context;
-        this.outputDelegate = outputDelegate;
-        this.dataProvider = dataProvider == null ? EMPTY_DATA_PROVIDER : dataProvider;
+        this(context, outputDelegate, null, dataProvider);
     }
 
     public CommandInvocationConfiguration(AeshContext context, InputDelegate inputDelegate) {
-        this.context = context;
-        this.inputDelegate = inputDelegate;
-        this.dataProvider =  EMPTY_DATA_PROVIDER;
+        this(context, null, inputDelegate, null);
     }
 
     public CommandInvocationConfiguration(AeshContext context, InputDelegate inputDelegate, DataProvider dataProvider) {
-        this.context = context;
-        this.inputDelegate = inputDelegate;
-        this.dataProvider = dataProvider == null ? EMPTY_DATA_PROVIDER : dataProvider;
+        this(context, null, inputDelegate, dataProvider);
     }
 
     public InputDelegate getInputRedirection() {

--- a/src/main/java/org/aesh/readline/ProcessManager.java
+++ b/src/main/java/org/aesh/readline/ProcessManager.java
@@ -84,7 +84,7 @@ public class ProcessManager {
             //if we have any operator input, we should see if we could inject it
             if(haveOperatorInput) {
                 peek().updateInjectedArgumentWithPipelinedData(new PipelineResource(
-                        process.execution().getCommandInvocation().getConfiguration().getPipedData()));
+                        peek().getCommandInvocation().getConfiguration().getPipedData()));
             }
             executeNext();
         }


### PR DESCRIPTION
Added support (impl and test) for:
- cmd1 < toto > titi
- cmd1 | cmd2 > titi
- cmd1 < toto | cmd2
- cmd1 < toto | cmd2 > titi
Found a bug in ProcessManager, seems that the wrong execution was called at some point.
