### PR TITLE
NPE in Executions

### DIFF
--- a/src/main/java/Example.java
+++ b/src/main/java/Example.java
@@ -135,6 +135,7 @@ public class Example {
                 .command(RunCommand.class)
                 .command(ClearCommand.class)
                 .command(GroupCommand.class)
+                .command(LongOutputCommand.class)
                 //example on how to build a command with a simple lambda
                 .command(new CommandBuilder().name("quit").command(commandInvocation -> {
                     commandInvocation.stop();
@@ -356,6 +357,26 @@ public class Example {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             commandInvocation.getShell().clear();
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "long-output", description = "")
+    public static class LongOutputCommand implements Command {
+
+        @Option(hasValue = false)
+        private boolean prompt;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < commandInvocation.getShell().size().getHeight() * 2; i++) {
+                builder.append("A sentence to say " + i + " time how long this content is." + Config.getLineSeparator());
+            }
+            commandInvocation.getShell().writeln(builder.toString(), true);
+            if (prompt) {
+                commandInvocation.inputLine(new Prompt("What was the name of your first pet?: "));
+            }
             return CommandResult.SUCCESS;
         }
     }

--- a/src/main/java/org/aesh/command/impl/Executions.java
+++ b/src/main/java/org/aesh/command/impl/Executions.java
@@ -254,6 +254,9 @@ class Executions {
                             if (!(op instanceof ExecutableOperator)) {
                                 throw new IllegalArgumentException("Op " + ot + " is not executable");
                             }
+                            if (processedCommand == null) {
+                                throw new IllegalArgumentException("Invalid command line, command is missing.");
+                            }
                             ExecutableOperator<CI> exec = (ExecutableOperator) op;
                             invocationConfiguration = config == null
                                     ? new CommandInvocationConfiguration(runtime.getAeshContext(), dataProvider)

--- a/src/main/java/org/aesh/command/impl/invocation/AeshCommandInvocation.java
+++ b/src/main/java/org/aesh/command/impl/invocation/AeshCommandInvocation.java
@@ -129,14 +129,14 @@ public final class AeshCommandInvocation<C extends Command<AeshCommandInvocation
     }
 
 
-   @Override
-   public void print(String msg) {
-       shell.write(msg);
-   }
+    @Override
+    public void print(String msg, boolean page) {
+        shell.write(msg, page);
+    }
 
     @Override
-    public void println(String msg) {
-        shell.writeln(msg);
+    public void println(String msg, boolean page) {
+        shell.writeln(msg, page);
     }
 
     @Override

--- a/src/main/java/org/aesh/command/impl/invocation/DefaultCommandInvocation.java
+++ b/src/main/java/org/aesh/command/impl/invocation/DefaultCommandInvocation.java
@@ -112,13 +112,13 @@ public class DefaultCommandInvocation<C extends Command<DefaultCommandInvocation
     }
 
     @Override
-    public void print(String msg) {
-        shell.write(msg);
+    public void print(String msg, boolean paging) {
+        shell.write(msg, paging);
     }
 
     @Override
-    public void println(String msg) {
-        shell.writeln(msg);
+    public void println(String msg, boolean paging) {
+        shell.writeln(msg, paging);
     }
 
     @Override
@@ -138,12 +138,12 @@ public class DefaultCommandInvocation<C extends Command<DefaultCommandInvocation
     private static class DefaultShell implements Shell {
 
         @Override
-        public void write(String out) {
+        public void write(String out, boolean paging) {
             System.out.print(out);
         }
 
         @Override
-        public void writeln(String out) {
+        public void writeln(String out, boolean paging) {
             System.out.println(out);
         }
 

--- a/src/main/java/org/aesh/command/impl/shell/ShellOutputDelegate.java
+++ b/src/main/java/org/aesh/command/impl/shell/ShellOutputDelegate.java
@@ -26,12 +26,12 @@ public class ShellOutputDelegate implements Shell {
     }
 
     @Override
-    public void write(String out) {
+    public void write(String out, boolean paging) {
         doWrite(out);
     }
 
     @Override
-    public void writeln(String out) {
+    public void writeln(String out, boolean paging) {
         doWrite(out+ Config.getLineSeparator());
     }
 

--- a/src/main/java/org/aesh/command/invocation/CommandInvocation.java
+++ b/src/main/java/org/aesh/command/invocation/CommandInvocation.java
@@ -130,12 +130,30 @@ public interface CommandInvocation {
     * Print a message on console
     * @param msg
     */
-    void print(String msg);
+    default void print(String msg) {
+        print(msg, false);
+    }
 
     /**
      * Print a new line with a message on console;
      * @param msg
      */
-    void println(String msg);
+    default void println(String msg) {
+        println(msg, false);
+    }
+
+    /**
+    * Print a message on console
+    * @param msg
+     * @param paging true to pause output for long content
+    */
+    void print(String msg, boolean paging);
+
+    /**
+     * Print a new line with a message on console;
+     * @param msg
+     * @param paging true to pause output for long content
+     */
+    void println(String msg, boolean paging);
 
 }

--- a/src/main/java/org/aesh/command/shell/Shell.java
+++ b/src/main/java/org/aesh/command/shell/Shell.java
@@ -32,12 +32,30 @@ public interface Shell {
     /**
      * @param out write out to the output stream
      */
-    void write(String out);
+    default void write(String out) {
+        write(out, false);
+    }
 
     /**
      * @param out write out to the output stream including a line separator at the end
      */
-    void writeln(String out);
+    default void writeln(String out) {
+        writeln(out, false);
+    }
+
+    /**
+    * Print a message on console
+    * @param msg
+     * @param paging True means that output longer than terminal height should be paused.
+    */
+    void write(String msg, boolean paging);
+
+    /**
+     * Print a new line with a message on console;
+     * @param msg
+     * @param paging True means that output longer than terminal height should be paused.
+     */
+    void writeln(String msg, boolean paging);
 
     /**
      * @param out write out to the output stream

--- a/src/main/java/org/aesh/readline/ShellImpl.java
+++ b/src/main/java/org/aesh/readline/ShellImpl.java
@@ -28,6 +28,8 @@ import org.aesh.terminal.tty.Size;
 import org.aesh.utils.Config;
 
 import java.util.concurrent.CountDownLatch;
+import org.aesh.terminal.Attributes;
+import org.aesh.utils.ANSI;
 
 /**
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
@@ -36,20 +38,108 @@ class ShellImpl implements Shell {
 
     private Connection connection;
     private Readline readline;
+    private StringBuilder outputCollector;
 
     ShellImpl(Connection connection, Readline readline) {
         this.connection = connection;
         this.readline = readline;
     }
 
-    @Override
-    public void write(String out) {
-        connection.write(out);
+    void startCollectOutput() {
+        outputCollector = null;
+    }
+
+    // handle "a la" 'more' scrolling
+    // Doesn't take into account wrapped lines (lines that are longer than the
+    // terminal width. This could make a page to skip some lines.
+    void printCollectedOutput() {
+        if (outputCollector == null) {
+            return;
+        }
+        try {
+            String line = outputCollector.toString();
+            if (line.isEmpty()) {
+                return;
+            }
+            // '\R' will match any line break.
+            // -1 to keep empty lines at the end of content.
+            String[] lines = line.split("\\R", -1);
+            int max = connection.size().getHeight();
+            int currentLines = 0;
+            int allLines = 0;
+            while (allLines < lines.length) {
+                if (currentLines > max - 2) {
+                    try {
+                        connection.write(ANSI.CURSOR_SAVE);
+                        int percentage = (allLines * 100) / lines.length;
+                        connection.write("--More(" + percentage + "%)--");
+                        Key k = read();
+                        connection.write(ANSI.CURSOR_RESTORE);
+                        connection.stdoutHandler().accept(ANSI.ERASE_LINE_FROM_CURSOR);
+                        if (k == null) { // interrupted, exit.
+                            allLines = lines.length;
+                        } else {
+                            switch (k) {
+                                case SPACE: {
+                                    currentLines = 0;
+                                    break;
+                                }
+                                case ENTER:
+                                case CTRL_M: { // On Mac, CTRL_M...
+                                    currentLines -= 1;
+                                    break;
+                                }
+                                case q: {
+                                    allLines = lines.length;
+                                    break;
+                                }
+                            }
+                        }
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ex);
+                    }
+                } else {
+                    String l = lines[allLines];
+                    currentLines += 1;
+                    allLines += 1;
+                    // Do not add an extra \n
+                    // The \n has been added by the previous line.
+                    if (allLines == lines.length) {
+                        if (l.isEmpty()) {
+                            continue;
+                        }
+                    }
+                    connection.write(l + Config.getLineSeparator());
+                }
+            }
+        } finally {
+            outputCollector = null;
+        }
     }
 
     @Override
-    public void writeln(String out) {
-        connection.write(out + Config.getLineSeparator());
+    public void write(String msg, boolean page) {
+        if (connection.supportsAnsi() && page) {
+            if (outputCollector == null) {
+                outputCollector = new StringBuilder();
+            }
+            outputCollector.append(msg);
+        } else {
+            connection.write(msg);
+        }
+    }
+
+    @Override
+    public void writeln(String msg, boolean page) {
+        if (connection.supportsAnsi() && page) {
+            if (outputCollector == null) {
+                outputCollector = new StringBuilder();
+            }
+            outputCollector.append(msg).append(Config.getLineSeparator());
+        } else {
+            connection.write(msg + Config.getLineSeparator());
+        }
     }
 
     @Override
@@ -69,6 +159,8 @@ class ShellImpl implements Shell {
 
     @Override
     public String readLine(Prompt prompt) throws InterruptedException {
+        printCollectedOutput();
+        startCollectOutput();
         final String[] out = {null};
         CountDownLatch latch = new CountDownLatch(1);
         readline.readline(connection, prompt, event -> {
@@ -90,19 +182,23 @@ class ShellImpl implements Shell {
         ActionDecoder decoder = new ActionDecoder();
         final Key[] key = {null};
         CountDownLatch latch = new CountDownLatch(1);
-        connection.setStdinHandler(keys -> {
-            decoder.add(keys);
-            if (decoder.hasNext()) {
-                key[0] = Key.findStartKey(decoder.next().buffer().array());
-                latch.countDown();
-            }
-        });
+        Attributes attributes = connection.enterRawMode();
         try {
-            // Wait until interrupted
-            latch.await();
-        }
-        finally {
-            connection.setStdinHandler(null);
+            connection.setStdinHandler(keys -> {
+                decoder.add(keys);
+                if (decoder.hasNext()) {
+                    key[0] = Key.findStartKey(decoder.next().buffer().array());
+                    latch.countDown();
+                }
+            });
+            try {
+                // Wait until interrupted
+                latch.await();
+            } finally {
+                connection.setStdinHandler(null);
+            }
+        } finally {
+            connection.setAttributes(attributes);
         }
         return key[0];
     }

--- a/src/test/java/org/aesh/command/invocation/AeshCommandInvocationServiceTest.java
+++ b/src/test/java/org/aesh/command/invocation/AeshCommandInvocationServiceTest.java
@@ -152,13 +152,13 @@ class FooCommandInvocation implements CommandInvocation {
     }
 
     @Override
-    public void print(String msg) {
-        commandInvocation.print(msg);
+    public void print(String msg, boolean paging) {
+        commandInvocation.print(msg, paging);
     }
 
     @Override
-    public void println(String msg) {
-        commandInvocation.println(msg);
+    public void println(String msg, boolean paging) {
+        commandInvocation.println(msg, paging);
     }
 
     public String getFoo() {


### PR DESCRIPTION
Wrongly formatted command such as: cmd || ==> NPE

Shell and CommandInvocation exposes 2 new methods to ask for paging. Added a long-output command to Example (can take a --prompt to observe that paged output is displayed prior to prompt).
Manually tested that input redirection bypass the paging and print it all.
