### PR TITLE
Minimize the number of time dynamic options are recomputed.

### DIFF
--- a/aesh/src/main/java/org/aesh/command/impl/internal/ProcessedCommand.java
+++ b/aesh/src/main/java/org/aesh/command/impl/internal/ProcessedCommand.java
@@ -294,8 +294,7 @@ public class ProcessedCommand<C extends Command> {
     }
 
    public void clear() {
-       for (ProcessedOption processedOption : getOptions())
-           processedOption.clear();
+       clearOptions();
        if(arguments != null)
            arguments.clear();
        if(argument != null)
@@ -303,6 +302,12 @@ public class ProcessedCommand<C extends Command> {
 
        parserExceptions.clear();
        completeStatus = null;
+    }
+
+    protected void clearOptions() {
+        for (ProcessedOption processedOption : getOptions()) {
+            processedOption.clear();
+        }
     }
 
     /**
@@ -434,8 +439,7 @@ public class ProcessedCommand<C extends Command> {
     }
 
     public void updateInvocationProviders(InvocationProviders invocationProviders) {
-        for (ProcessedOption option : getOptions())
-            option.updateInvocationProviders(invocationProviders);
+        updateOptionsInvocationProviders(invocationProviders);
         if (argument != null) {
             argument.updateInvocationProviders(invocationProviders);
         }
@@ -443,6 +447,12 @@ public class ProcessedCommand<C extends Command> {
             arguments.updateInvocationProviders(invocationProviders);
         }
         activator = invocationProviders.getCommandActivatorProvider().enhanceCommandActivator(activator);
+    }
+
+    protected void updateOptionsInvocationProviders(InvocationProviders invocationProviders) {
+        for (ProcessedOption option : getOptions()) {
+            option.updateInvocationProviders(invocationProviders);
+        }
     }
 
     public void addParserException(CommandLineParserException exception) {

--- a/aesh/src/main/java/org/aesh/command/impl/parser/AeshCommandLineParser.java
+++ b/aesh/src/main/java/org/aesh/command/impl/parser/AeshCommandLineParser.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.aesh.command.map.MapCommand;
 import org.aesh.command.map.MapCommandPopulator;
+import org.aesh.command.map.MapProcessedCommandBuilder.MapProcessedCommand;
 
 /**
  * A simple command line parser.
@@ -327,6 +328,12 @@ public class AeshCommandLineParser<C extends Command> implements CommandLinePars
                 processedCommand.addParserException(ope);
             }
             if (mode == Mode.STRICT) {
+                if (processedCommand instanceof MapProcessedCommand) {
+                    MapCommand mc = (MapCommand) processedCommand.getCommand();
+                    if (!mc.checkForRequiredOptions(iter.baseLine())) {
+                        return;
+                    }
+                }
                 RequiredOptionException re = checkForMissingRequiredOptions(processedCommand);
                 if (re != null)
                     processedCommand.addParserException(re);

--- a/aesh/src/main/java/org/aesh/command/map/MapCommand.java
+++ b/aesh/src/main/java/org/aesh/command/map/MapCommand.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.Command;
+import org.aesh.parser.ParsedLine;
 
 /**
  *
@@ -57,6 +58,10 @@ public abstract class MapCommand<T extends CommandInvocation> implements Command
 
     public Map<String, Object> getValues() {
         return Collections.unmodifiableMap(values);
+    }
+
+    public boolean checkForRequiredOptions(ParsedLine pl) {
+        return true;
     }
 
     void resetAll() {

--- a/aesh/src/main/java/org/aesh/command/map/MapCommandPopulator.java
+++ b/aesh/src/main/java/org/aesh/command/map/MapCommandPopulator.java
@@ -34,7 +34,7 @@ import org.aesh.command.populator.CommandPopulator;
 import org.aesh.command.validator.OptionValidatorException;
 import org.aesh.readline.AeshContext;
 import org.aesh.command.invocation.InvocationProviders;
-import org.aesh.command.Command;
+import org.aesh.command.map.MapProcessedCommandBuilder.MapProcessedCommand;
 import org.aesh.command.parser.CommandLineParserException;
 
 /**
@@ -43,7 +43,7 @@ import org.aesh.command.parser.CommandLineParserException;
  *
  * @author jdenise@redhat.com
  */
-public class MapCommandPopulator implements CommandPopulator<Object, Command> {
+public class MapCommandPopulator implements CommandPopulator<Object, MapCommand> {
 
     private final MapCommand<?> instance;
     private final Map<String, String> unknownOptions = new HashMap<>();
@@ -54,7 +54,7 @@ public class MapCommandPopulator implements CommandPopulator<Object, Command> {
     }
 
     @Override
-    public void populateObject(ProcessedCommand<Command> processedCommand,
+    public void populateObject(ProcessedCommand<MapCommand> processedCommand,
             InvocationProviders invocationProviders,
             AeshContext aeshContext, CommandLineParser.Mode validate)
             throws CommandLineParserException, OptionValidatorException {
@@ -108,7 +108,10 @@ public class MapCommandPopulator implements CommandPopulator<Object, Command> {
             }
         }
 
-        for (ProcessedOption option : processedCommand.getOptions()) {
+        // At this point, if no dynamic options have been retrieved it means
+        // that no dynamic options have been provided, so no need to compute the set now.
+        MapProcessedCommand mpc = (MapProcessedCommand) processedCommand;
+        for (ProcessedOption option : mpc.getCurrentOptions()) {
             // Do not erase the value that would have been set as an unknown option.
             if (!unknownOptions.containsKey(option.name())) {
                 if (option.getValue() != null) {


### PR DESCRIPTION
The retrieval of dynamic options can be costly and needed only at completion time.
This change refactors ProcessedCommand in order for MapProcessedCommand to minimize the number of time options are retrieved.
