### PR TITLE
No need for new line when exiting

### DIFF
--- a/aesh/src/main/java/org/aesh/readline/ReadlineConsole.java
+++ b/aesh/src/main/java/org/aesh/readline/ReadlineConsole.java
@@ -175,7 +175,6 @@ public class ReadlineConsole implements Console, Consumer<Connection> {
             this.connection = connection;
 
         connection.setCloseHandler((Void t) -> {
-            connection.write(Config.getLineSeparator());
             doStop(false);
         });
         if(!settings.isEchoCtrl()) {


### PR DESCRIPTION
When using the "exit" command from aesh extension, 2 new lines are printed. The expected one (to execute the command), and a not expected one printed by the console when existing.
In order to still have a new line when Ctrl-D is typed, aesh-readline Ctrl-D action must print a new line prior to close the connection. That is:https://github.com/aeshell/aesh-readline/pull/34
 
