### PR TITLE
Fix for AESH-488, ReadlineConsole doesn't take into account logging flag

### DIFF
--- a/aesh/src/main/java/org/aesh/command/impl/AeshCommandRuntime.java
+++ b/aesh/src/main/java/org/aesh/command/impl/AeshCommandRuntime.java
@@ -210,6 +210,7 @@ public class AeshCommandRuntime<C extends Command<CI>, CI extends CommandInvocat
     public Executor<CI> buildExecutor(String line) throws CommandNotFoundException,
             CommandLineParserException, OptionValidatorException,
             CommandValidatorException, IOException {
+        LOGGER.fine("Command: " + line);
         List<ParsedLine> lines = new LineParser().parseLine(line, -1, parseBrackets, operators);
         List<Execution<CI>> executions = Executions.buildExecution(lines, this);
         return new Executor<>(executions);

--- a/aesh/src/main/java/org/aesh/readline/ReadlineConsole.java
+++ b/aesh/src/main/java/org/aesh/readline/ReadlineConsole.java
@@ -104,8 +104,7 @@ public class ReadlineConsole implements Console, Consumer<Connection> {
 
    private final EnumMap<ReadlineFlag, Integer> readlineFlags = new EnumMap<>(ReadlineFlag.class);
 
-   public ReadlineConsole(Settings<? extends Command<? extends CommandInvocation>, ? extends CommandInvocation, ? extends ConverterInvocation, ? extends CompleterInvocation, ? extends ValidatorInvocation, ? extends OptionActivator, ? extends CommandActivator> givenSettings) {
-        LoggerUtil.doLog();
+    public ReadlineConsole(Settings<? extends Command<? extends CommandInvocation>, ? extends CommandInvocation, ? extends ConverterInvocation, ? extends CompleterInvocation, ? extends ValidatorInvocation, ? extends OptionActivator, ? extends CommandActivator> givenSettings) {
         if(givenSettings == null)
             settings = SettingsBuilder.builder().build();
         else


### PR DESCRIPTION
- Removed call to doLog from ReadlineConsole, that is handled in SettingsBuilder if logging is set to true.
- Added a fine trace for each executed command.