### PR TITLE
Allow short-name option without =

### DIFF
--- a/aesh/src/main/java/org/aesh/command/impl/parser/AeshOptionParser.java
+++ b/aesh/src/main/java/org/aesh/command/impl/parser/AeshOptionParser.java
@@ -117,12 +117,15 @@ public class AeshOptionParser implements OptionParser {
             processList(option, rest);
         }
         else if (!rest.contains(EQUALS)) {
-            // we might have two or more options in a group
-            // if so, we only allow options (boolean) without value
+            // Either we have two or more boolean options in a group
+            // or the value is appended without the EQUALS
             if (rest.length() > 0 && !option.isLongNameUsed()) {
-                //first we add the first option
-                if(!option.hasValue()) {
-                    option.setLongNameUsed(false);
+                option.setLongNameUsed(false);
+                if (option.hasValue()) {
+                    doAddValueToOption(option, rest);
+                    return;
+                } else  {
+                    // we add the first option
                     option.addValue("true");
                 }
 

--- a/aesh/src/test/java/org/aesh/command/parser/CommandLineParserTest.java
+++ b/aesh/src/test/java/org/aesh/command/parser/CommandLineParserTest.java
@@ -111,6 +111,11 @@ public class CommandLineParserTest {
         assertEquals("bar", p1.equal);
         assertEquals("g", p1.define.get("f"));
         assertEquals("/tmp/file.txt ", p1.arguments.get(0));
+
+        parser.populateObject("test -ebar -Df=g /tmp/file.txt", invocationProviders, aeshContext, CommandLineParser.Mode.VALIDATE);
+        assertEquals("bar", p1.equal);
+        assertEquals("g", p1.define.get("f"));
+        assertEquals("/tmp/file.txt", p1.arguments.get(0));
     }
 
     @Test


### PR DESCRIPTION
Allow `@Option(shortName = 'e') String e` be used as `test -ebar`.