### PR TITLE
Put description in its own line for cli printHelp

### DIFF
--- a/aesh/src/main/java/org/aesh/command/impl/internal/ProcessedCommand.java
+++ b/aesh/src/main/java/org/aesh/command/impl/internal/ProcessedCommand.java
@@ -407,7 +407,7 @@ public class ProcessedCommand<C extends Command> {
             sb.append(Config.getLineSeparator()).append("Argument:").append(Config.getLineSeparator());
             sb.append(argument.getFormattedOption(2, maxLength+4, width)).append(Config.getLineSeparator());
         }
-        return "Usage: "+ name()+" "+ description()+ Config.getLineSeparator()+sb.toString();
+        return "Usage: "+ name()+ Config.getLineSeparator() + description()+ Config.getLineSeparator()+sb.toString();
     }
 
     @Override

--- a/aesh/src/test/java/org/aesh/command/builder/CommandLineFormatterTest.java
+++ b/aesh/src/test/java/org/aesh/command/builder/CommandLineFormatterTest.java
@@ -60,7 +60,7 @@ public class CommandLineFormatterTest {
                 .processedCommand(pb.create())
                 .create();
 
-        assertEquals("Usage: man [OPTION...]"+ Config.getLineSeparator()+
+        assertEquals("Usage: man" + Config.getLineSeparator() + "[OPTION...]"+ Config.getLineSeparator()+
                         Config.getLineSeparator()+
                         "Options:"+ Config.getLineSeparator()+
                         "  -d, --debug    emit debugging messages"+Config.getLineSeparator()+
@@ -103,7 +103,7 @@ public class CommandLineFormatterTest {
 
         CommandLineParser clp = new CommandLineParserBuilder().processedCommand(pb.create()).create();
 
-        assertEquals("Usage: man [OPTION...]"+ Config.getLineSeparator()+
+        assertEquals("Usage: man" + Config.getLineSeparator() + "[OPTION...]"+ Config.getLineSeparator()+
                         Config.getLineSeparator()+
                         "Options:"+ Config.getLineSeparator()+
                         "  -d, --debug            emit debugging messages"+Config.getLineSeparator()+
@@ -157,7 +157,7 @@ public class CommandLineFormatterTest {
         clpGit.addChildParser(clpBranch);
         clpGit.addChildParser(clpRebase);
 
-         assertEquals("Usage: git [OPTION...]" + Config.getLineSeparator() +
+         assertEquals("Usage: git" + Config.getLineSeparator() + "[OPTION...]" + Config.getLineSeparator() +
                          Config.getLineSeparator() +
                          "Options:" + Config.getLineSeparator() +
                          "  -h, --help  display help info" + Config.getLineSeparator()


### PR DESCRIPTION
The old behaviour of printing the help text is as follows:

```
Usage: command description

Options:
  --help
```

This is confusing because in the 'Usage' line, we're expecting the
cli-options to appear, and one might think that 'description' is a CLI
sub-command instead of the description itself (especially if the
description is short).

Instead, this commit puts the description in a new line to avoid this
confusion.

```
Usage: command
description

Options:
  --help
```