### PR TITLE
printHelp in CommandRuntime should consider full param string

### DIFF
--- a/aesh/src/main/java/org/aesh/command/CommandRuntime.java
+++ b/aesh/src/main/java/org/aesh/command/CommandRuntime.java
@@ -96,7 +96,7 @@ public interface CommandRuntime<CI extends CommandInvocation> {
     default String commandInfo(String line) {
         try {
             String name = Parser.findFirstWord(line);
-            return getCommandRegistry().getCommand(name, line).printHelp(name);
+            return getCommandRegistry().getCommand(name, line).printHelp(line);
         }
         catch (CommandNotFoundException e) {
             return null;


### PR DESCRIPTION
In `CommandRuntime`, once we get the desired `CommandContainer` object
for method `commandInfo`, we should pass the full 'line' String to
`commandContainer.printHelp`.

If the CommandContainer is a group command, the `printHelp` method
accepts multiple tokens in the parameter to help it find the correct
child parser (or sub-command/sub-groupcommand) to invoke the `printHelp`
method.

for e.g the 'line' string can be: 'main-group sub-group'

With the change in that commit, the CommandContainer for 'main-group'
will figure out that we want to find the child parser of 'sub-group' to
print its help text.