### PR TITLE
Align command name and command description and add color

### DIFF
--- a/aesh/src/main/java/org/aesh/command/impl/parser/CommandLineParser.java
+++ b/aesh/src/main/java/org/aesh/command/impl/parser/CommandLineParser.java
@@ -152,6 +152,10 @@ public interface CommandLineParser<CI extends CommandInvocation> {
 
     void doPopulate(ProcessedCommand<Command<CI>, CI> processedCommand, InvocationProviders invocationProviders, AeshContext aeshContext, Mode mode) throws CommandLineParserException, OptionValidatorException;
 
+    String getFormattedCommand(int offset, int descriptionStart);
+
+    void updateAnsiMode(boolean mode);
+
     enum Mode {
         COMPLETION, STRICT, VALIDATE, NONE
     }

--- a/aesh/src/test/java/org/aesh/command/builder/CommandLineFormatterTest.java
+++ b/aesh/src/test/java/org/aesh/command/builder/CommandLineFormatterTest.java
@@ -169,6 +169,10 @@ public class CommandLineFormatterTest {
         CommandLineParser<CommandInvocation> clpBranch = CommandLineParserBuilder.builder().processedCommand(branch.create()).create();
         CommandLineParser<CommandInvocation> clpRebase = CommandLineParserBuilder.builder().processedCommand(rebase.create()).create();
 
+        clpGit.updateAnsiMode(false);
+        clpBranch.updateAnsiMode(false);
+        clpRebase.updateAnsiMode(false);
+
         clpGit.addChildParser(clpBranch);
         clpGit.addChildParser(clpRebase);
 
@@ -177,8 +181,8 @@ public class CommandLineFormatterTest {
                          "Options:" + getLineSeparator() +
                          "  -h, --help  display help info" + getLineSeparator()
                          + getLineSeparator()+"git commands:"+ getLineSeparator()+
-                         "    branch  branching"+ getLineSeparator()+
-                         "    rebase  [OPTION...]"+ getLineSeparator(),
+                         "    " + "branch" + "  branching" + getLineSeparator() +
+                         "    " + "rebase" + "  [OPTION...]"+ getLineSeparator(),
                  clpGit.printHelp());
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
-      <readline.version>1.15</readline.version>
+      <readline.version>1.16</readline.version>
     </properties>
  
     <developers>


### PR DESCRIPTION
![aesh-output](https://user-images.githubusercontent.com/630746/54851565-c986d780-4cc0-11e9-8044-0a59fbfcc8f5.png)

This commit aligns the command names and the command description, and adds a dash of color to the command name (can be disabled by calling updateAnsiMode(false))