### PR TITLE
Warn user of wrong command

### DIFF
--- a/aesh/src/main/java/org/aesh/command/container/DefaultCommandContainer.java
+++ b/aesh/src/main/java/org/aesh/command/container/DefaultCommandContainer.java
@@ -71,6 +71,10 @@ public abstract class DefaultCommandContainer<CI extends CommandInvocation> impl
         if (getParser().getProcessedCommand().parserExceptions().size() > 0) {
             throw getParser().getProcessedCommand().parserExceptions().get(0);
         }
+
+        if (getParser().parsedCommand() == null) {
+            throw new CommandLineParserException("Command and/or sub-command is not valid!");
+        }
         getParser().parsedCommand().getCommandPopulator().populateObject(getParser().parsedCommand().getProcessedCommand(),
                 invocationProviders, aeshContext, CommandLineParser.Mode.VALIDATE);
         return getParser().parsedCommand().getProcessedCommand();


### PR DESCRIPTION
In case the user is invoking a wrong command and/or sub-command, a NPE
is thrown. This PR attempts to throw a more meaningful exception
(CommandLineparserException) and the reason for the stacktrace.