### PR TITLE
Make FileCompleterGenerator public

### DIFF
--- a/aesh/src/main/java/org/aesh/util/completer/FileCompleterGenerator.java
+++ b/aesh/src/main/java/org/aesh/util/completer/FileCompleterGenerator.java
@@ -29,13 +29,13 @@ import org.aesh.terminal.utils.Config;
 /**
  * @author Aesh team
  */
-class FileCompleterGenerator {
+public class FileCompleterGenerator {
 
     /**
      * @param command the command we generate a completion file for
      * @return completion file content
      */
-    String generateCompleterFile(CommandLineParser<CommandInvocation> command) {
+    public String generateCompleterFile(CommandLineParser<CommandInvocation> command) {
         StringBuilder out = new StringBuilder();
 
         out.append(generateHeader(command.getProcessedCommand().name()));


### PR DESCRIPTION
## Summary
- Make `FileCompleterGenerator` class public
- Make `generateCompleterFile` method public

This allows external projects to generate shell completion scripts directly from their command parsers, without having to go through `CompleterCommand`.

The use case is the Infinispan CLI which needs to generate completion scripts at build/package time for inclusion in platform packages (deb, rpm, Homebrew).

Created with the assistance of an AI tool