### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (e.g. 3.6). If unspecified, derived from POM version by removing -dev suffix.'
+        required: false
+      next_version:
+        description: 'Next development version (e.g. 3.7-dev). If unspecified, bumps minor version and appends -dev.'
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          server-id: jboss-testing-repository
+          server-username: NEXUS_USER
+          server-password: NEXUS_TOKEN
+          gpg-private-key: ${{ secrets.GPG_ARMORED }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Determine versions
+        id: versions
+        run: |
+          POM_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "POM version: $POM_VERSION"
+
+          if [ -n "${{ github.event.inputs.release_version }}" ]; then
+            RELEASE_VERSION="${{ github.event.inputs.release_version }}"
+          else
+            RELEASE_VERSION="${POM_VERSION%-dev}"
+            if [ "$RELEASE_VERSION" = "$POM_VERSION" ]; then
+              echo "::error::POM version '$POM_VERSION' does not end with -dev and no release version was specified."
+              exit 1
+            fi
+          fi
+
+          if [ -n "${{ github.event.inputs.next_version }}" ]; then
+            NEXT_VERSION="${{ github.event.inputs.next_version }}"
+          else
+            MAJOR="${RELEASE_VERSION%%.*}"
+            MINOR="${RELEASE_VERSION#*.}"
+            NEXT_MINOR=$((MINOR + 1))
+            NEXT_VERSION="${MAJOR}.${NEXT_MINOR}-dev"
+          fi
+
+          echo "Release version: $RELEASE_VERSION"
+          echo "Next version: $NEXT_VERSION"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set release version
+        run: |
+          mvn versions:set -DnewVersion=${{ steps.versions.outputs.release_version }} -DgenerateBackupPoms=false
+          git commit -am "Release ${{ steps.versions.outputs.release_version }}"
+
+      - name: Build and deploy
+        run: mvn clean deploy -Prelease -DskipTests
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_TOKEN: ${{ secrets.NEXUS_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Tag release
+        run: |
+          git tag -a "v${{ steps.versions.outputs.release_version }}" -m "Release ${{ steps.versions.outputs.release_version }}"
+
+      - name: Set next development version
+        run: |
+          mvn versions:set -DnewVersion=${{ steps.versions.outputs.next_version }} -DgenerateBackupPoms=false
+          git commit -am "Next version ${{ steps.versions.outputs.next_version }}"
+
+      - name: Push changes and tag
+        run: |
+          git push origin HEAD
+          git push origin "v${{ steps.versions.outputs.release_version }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.versions.outputs.release_version }}" \
+            --title "Release ${{ steps.versions.outputs.release_version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-triggered release workflow with optional `release_version` and `next_version` inputs
- Derives release version from POM by stripping `-dev` suffix when not specified; auto-bumps minor version for next dev cycle
- Handles GPG-signed artifact deployment to Nexus, git tagging, and GitHub release creation with auto-generated notes
- Uses `GPG_ARMORED`, `GPG_PASSPHRASE`, `NEXUS_USER`, and `NEXUS_TOKEN` repository secrets

## Test plan
- [ ] Verify workflow appears in Actions tab after merge
- [ ] Run workflow with explicit `release_version` and `next_version` inputs
- [ ] Run workflow with no inputs to validate auto-derivation from POM version
- [ ] Confirm GPG signing, Nexus deployment, git tag, and GitHub release are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)