### PR TITLE
fix: resolve group subcommand aliases in getChildParser

### DIFF
--- a/aesh/src/main/java/org/aesh/command/impl/parser/AeshCommandLineParser.java
+++ b/aesh/src/main/java/org/aesh/command/impl/parser/AeshCommandLineParser.java
@@ -28,7 +28,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandLifecycle;
+import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.HelpEntry;
 import org.aesh.command.HelpSectionProvider;
 import org.aesh.command.container.CommandContainer;
@@ -151,8 +153,12 @@ public class AeshCommandLineParser<CI extends CommandInvocation> implements Comm
         if (lazyChildClasses == null)
             return null;
         Class<? extends Command> clazz = lazyChildClasses.remove(name);
-        if (clazz == null)
-            return null;
+        if (clazz == null) {
+            // Check if the name matches an alias of any lazy child
+            clazz = findLazyChildByAlias(name);
+            if (clazz == null)
+                return null;
+        }
         try {
             AeshCommandContainerBuilder<CI> builder = new AeshCommandContainerBuilder<>();
             CommandContainer<CI> container = builder.create(clazz);
@@ -162,6 +168,35 @@ public class AeshCommandLineParser<CI extends CommandInvocation> implements Comm
         } catch (CommandLineParserException e) {
             return null;
         }
+    }
+
+    private Class<? extends Command> findLazyChildByAlias(String alias) {
+        if (lazyChildClasses == null)
+            return null;
+        for (Map.Entry<String, Class<? extends Command>> entry : lazyChildClasses.entrySet()) {
+            Class<? extends Command> clazz = entry.getValue();
+            String[] aliases = getCommandAliases(clazz);
+            if (aliases != null) {
+                for (String a : aliases) {
+                    if (a.equals(alias)) {
+                        // Remove by primary name so it won't be resolved again
+                        lazyChildClasses.remove(entry.getKey());
+                        return clazz;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String[] getCommandAliases(Class<? extends Command> clazz) {
+        CommandDefinition cd = clazz.getAnnotation(CommandDefinition.class);
+        if (cd != null)
+            return cd.aliases();
+        GroupCommandDefinition gcd = clazz.getAnnotation(GroupCommandDefinition.class);
+        if (gcd != null)
+            return gcd.aliases();
+        return null;
     }
 
     private void applyStoredProviders(CommandLineParser<CI> child) {
@@ -242,6 +277,9 @@ public class AeshCommandLineParser<CI extends CommandInvocation> implements Comm
         if (childParsers != null) {
             for (CommandLineParser<CI> clp : childParsers) {
                 if (clp.getProcessedCommand().name().equals(name))
+                    return clp;
+                if (clp.getProcessedCommand().getAliases() != null
+                        && clp.getProcessedCommand().getAliases().contains(name))
                     return clp;
             }
         }

--- a/aesh/src/test/java/org/aesh/command/GroupCommandRuntimeTest.java
+++ b/aesh/src/test/java/org/aesh/command/GroupCommandRuntimeTest.java
@@ -119,6 +119,60 @@ public class GroupCommandRuntimeTest {
         lastVerbose = false;
     }
 
+    @Test
+    public void testGroupCommandSubcommandAliases() throws Exception {
+        CommandRegistry<CommandInvocation> registry = AeshCommandRegistryBuilder.builder()
+                .command(AliasGroupCommand.class).create();
+        CommandRuntime<CommandInvocation> runtime = AeshCommandRuntimeBuilder.builder()
+                .commandRegistry(registry).build();
+
+        // Test: resolve by primary name
+        reset();
+        runtime.executeCommand("agroup install");
+        assertEquals("install", lastSubcommand);
+
+        // Test: resolve by alias
+        reset();
+        runtime.executeCommand("agroup i");
+        assertEquals("install", lastSubcommand);
+
+        // Test: second subcommand by alias
+        reset();
+        runtime.executeCommand("agroup l");
+        assertEquals("list", lastSubcommand);
+
+        // Test: second subcommand by primary name
+        reset();
+        runtime.executeCommand("agroup list");
+        assertEquals("list", lastSubcommand);
+    }
+
+    @CommandDefinition(name = "install", aliases = { "i" }, description = "Install something")
+    public static class AliasInstallCommand implements Command<CommandInvocation> {
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            lastSubcommand = "install";
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "list", aliases = { "l" }, description = "List things")
+    public static class AliasListCommand implements Command<CommandInvocation> {
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            lastSubcommand = "list";
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "agroup", description = "", groupCommands = { AliasInstallCommand.class, AliasListCommand.class })
+    public static class AliasGroupCommand implements Command<CommandInvocation> {
+        @Override
+        public CommandResult execute(CommandInvocation invocation) {
+            return CommandResult.SUCCESS;
+        }
+    }
+
     @CommandDefinition(name = "version", description = "Show version")
     public static class VersionCommand implements Command<CommandInvocation> {
         @Override


### PR DESCRIPTION
## Problem

Group subcommands declared with `@CommandDefinition(aliases = {"l"}, ...)` were not resolvable by their alias names. For example, given:

```java
@CommandDefinition(name = "list", aliases = {"l"}, description = "Lists items.")
public static class ListCommand implements Command<CommandInvocation> { ... }

@CommandDefinition(name = "parent", groupCommands = { ListCommand.class })
public static class ParentCommand implements Command<CommandInvocation> { ... }
```

Running `parent list` works, but `parent l` fails with "Command and/or sub-command is not valid!".

## Root Cause

Two places in `AeshCommandLineParser` only check by primary name:

1. **`getChildParser(String)`** — iterates resolved child parsers but only checks `processedCommand.name()`, never `getAliases()`
2. **`resolveLazyChild(String)`** — does a direct `Map.remove(name)` on the lazy child map (keyed by primary name only)

The aliases are correctly stored in `ProcessedCommand` via the builder, but never consulted during subcommand resolution.

## Fix

- `getChildParser()`: also check `getAliases()` on already-resolved child parsers
- `resolveLazyChild()`: when direct name lookup fails, scan lazy child classes for matching aliases via annotation introspection (`@CommandDefinition.aliases()` / `@GroupCommandDefinition.aliases()`)
- Added test `testGroupCommandSubcommandAliases` covering both primary name and alias resolution

## Impact

This was discovered in [jbang](https://github.com/jbangdev/jbang) after migrating from picocli to aesh — all `jdk` subcommand aliases (`jdk l`, `jdk i`, `jdk u`, `jdk env`, `jdk x`) stopped working.